### PR TITLE
fix(detectable-elements): fix iso-* contour gradients in `roc-space`

### DIFF
--- a/libraries/detectable-elements/package.json
+++ b/libraries/detectable-elements/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@decidables/decidables-elements": "^0.5.5",
     "@decidables/detectable-math": "^0.2.5",
+    "color": "^5.0.3",
     "d3": "^7.9.0",
     "jstat": "^1.9.6",
     "lit": "^3.3.1"

--- a/libraries/detectable-elements/src/components/roc-space.js
+++ b/libraries/detectable-elements/src/components/roc-space.js
@@ -1,6 +1,7 @@
 
 import {css, html, render} from 'lit';
 import * as d3 from 'd3';
+import color from 'color';
 
 import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
 import SDTMath from '@decidables/detectable-math';
@@ -560,23 +561,29 @@ export default class ROCSpace extends DecidablesMixinResizeable(DetectableElemen
         const contours = d3.contours()
           .size([n, n])
           .thresholds(contourThresholds);
-        const contourColorStart = this.getComputedStyleValue((this.contour === 'bias')
-          ? '---color-element-background'
-          : (this.contour === 'sensitivity')
-            ? '---color-d'
-            : (this.contour === 'accuracy')
-              ? '---color-acc-dark'
-              : null);
-        const contourColorEnd = this.getComputedStyleValue((this.contour === 'bias')
-          ? '---color-c'
-          : (this.contour === 'sensitivity')
+        const contourColorStart = this.getComputedStyleValue(
+          (this.contour === 'bias')
             ? '---color-element-background'
-            : (this.contour === 'accuracy')
+            : (this.contour === 'sensitivity')
+              ? '---color-d'
+              : (this.contour === 'accuracy')
+                ? '---color-acc-dark'
+                : null,
+        );
+        const contourColorEnd = this.getComputedStyleValue(
+          (this.contour === 'bias')
+            ? '---color-c'
+            : (this.contour === 'sensitivity')
               ? '---color-element-background'
-              : null);
+              : (this.contour === 'accuracy')
+                ? '---color-element-background'
+                : null,
+        );
         const contourColor = d3.scaleLinear()
           .domain(d3.extent(contourThresholds))
-          .interpolate(() => { return d3.interpolateRgb(contourColorStart, contourColorEnd); });
+          .interpolate(() => {
+            return d3.interpolateRgb(color(contourColorStart).hex(), color(contourColorEnd).hex());
+          });
         //  DATA-JOIN
         const contourPlotUpdate = underlayerMerge.selectAll('.plot-contour')
           .data([this.contour]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,12 +1430,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@decidables/accumulable-elements@npm:^0.3.5, @decidables/accumulable-elements@workspace:libraries/accumulable-elements":
+"@decidables/accumulable-elements@npm:^0.3.6, @decidables/accumulable-elements@workspace:libraries/accumulable-elements":
   version: 0.0.0-use.local
   resolution: "@decidables/accumulable-elements@workspace:libraries/accumulable-elements"
   dependencies:
-    "@decidables/accumulable-math": "npm:^0.2.4"
-    "@decidables/decidables-elements": "npm:^0.5.4"
+    "@decidables/accumulable-math": "npm:^0.2.5"
+    "@decidables/decidables-elements": "npm:^0.5.5"
     "@lit-labs/motion": "npm:^1.0.9"
     "@observablehq/plot": "npm:^0.6.17"
     bayes.js: "https://github.com/akrawitz/bayes.js.git#commit=c7b091b75f85a86b6a3965a983b31e23d9ef456f"
@@ -1445,7 +1445,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@decidables/accumulable-math@npm:^0.2.4, @decidables/accumulable-math@workspace:libraries/accumulable-math":
+"@decidables/accumulable-math@npm:^0.2.5, @decidables/accumulable-math@workspace:libraries/accumulable-math":
   version: 0.0.0-use.local
   resolution: "@decidables/accumulable-math@workspace:libraries/accumulable-math"
   dependencies:
@@ -1457,8 +1457,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@decidables/accumulable@workspace:sites/accumulable"
   dependencies:
-    "@decidables/accumulable-elements": "npm:^0.3.5"
-    "@decidables/decidables-site": "npm:^0.6.0"
+    "@decidables/accumulable-elements": "npm:^0.3.6"
+    "@decidables/decidables-site": "npm:^0.6.1"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.47.0"
@@ -1474,11 +1474,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@decidables/dable@workspace:sites/dable"
   dependencies:
-    "@decidables/accumulable-elements": "npm:^0.3.5"
-    "@decidables/decidables-site": "npm:^0.6.0"
-    "@decidables/detectable-elements": "npm:^0.4.4"
-    "@decidables/discountable-elements": "npm:^0.6.2"
-    "@decidables/prospectable-elements": "npm:^0.4.4"
+    "@decidables/accumulable-elements": "npm:^0.3.6"
+    "@decidables/decidables-site": "npm:^0.6.1"
+    "@decidables/detectable-elements": "npm:^0.4.5"
+    "@decidables/discountable-elements": "npm:^0.6.3"
+    "@decidables/prospectable-elements": "npm:^0.4.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.47.0"
@@ -1490,7 +1490,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@decidables/decidables-elements@npm:^0.5.4, @decidables/decidables-elements@workspace:libraries/decidables-elements":
+"@decidables/decidables-elements@npm:^0.5.5, @decidables/decidables-elements@workspace:libraries/decidables-elements":
   version: 0.0.0-use.local
   resolution: "@decidables/decidables-elements@workspace:libraries/decidables-elements"
   dependencies:
@@ -1500,7 +1500,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@decidables/decidables-site@npm:^0.6.0, @decidables/decidables-site@workspace:libraries/decidables-site":
+"@decidables/decidables-site@npm:^0.6.1, @decidables/decidables-site@workspace:libraries/decidables-site":
   version: 0.0.0-use.local
   resolution: "@decidables/decidables-site@workspace:libraries/decidables-site"
   dependencies:
@@ -1512,11 +1512,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@decidables/decidables@workspace:sites/decidables"
   dependencies:
-    "@decidables/accumulable-elements": "npm:^0.3.5"
-    "@decidables/decidables-site": "npm:^0.6.0"
-    "@decidables/detectable-elements": "npm:^0.4.4"
-    "@decidables/discountable-elements": "npm:^0.6.2"
-    "@decidables/prospectable-elements": "npm:^0.4.4"
+    "@decidables/accumulable-elements": "npm:^0.3.6"
+    "@decidables/decidables-site": "npm:^0.6.1"
+    "@decidables/detectable-elements": "npm:^0.4.5"
+    "@decidables/discountable-elements": "npm:^0.6.3"
+    "@decidables/prospectable-elements": "npm:^0.4.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.47.0"
@@ -1528,12 +1528,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@decidables/detectable-elements@npm:^0.4.4, @decidables/detectable-elements@workspace:libraries/detectable-elements":
+"@decidables/detectable-elements@npm:^0.4.5, @decidables/detectable-elements@workspace:libraries/detectable-elements":
   version: 0.0.0-use.local
   resolution: "@decidables/detectable-elements@workspace:libraries/detectable-elements"
   dependencies:
-    "@decidables/decidables-elements": "npm:^0.5.4"
-    "@decidables/detectable-math": "npm:^0.2.4"
+    "@decidables/decidables-elements": "npm:^0.5.5"
+    "@decidables/detectable-math": "npm:^0.2.5"
+    color: "npm:^5.0.3"
     d3: "npm:^7.9.0"
     gulp: "npm:^5.0.1"
     jstat: "npm:^1.9.6"
@@ -1541,7 +1542,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@decidables/detectable-math@npm:^0.2.4, @decidables/detectable-math@workspace:libraries/detectable-math":
+"@decidables/detectable-math@npm:^0.2.5, @decidables/detectable-math@workspace:libraries/detectable-math":
   version: 0.0.0-use.local
   resolution: "@decidables/detectable-math@workspace:libraries/detectable-math"
   dependencies:
@@ -1554,8 +1555,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@decidables/detectable@workspace:sites/detectable"
   dependencies:
-    "@decidables/decidables-site": "npm:^0.6.0"
-    "@decidables/detectable-elements": "npm:^0.4.4"
+    "@decidables/decidables-site": "npm:^0.6.1"
+    "@decidables/detectable-elements": "npm:^0.4.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.47.0"
@@ -1567,12 +1568,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@decidables/discountable-elements@npm:^0.6.2, @decidables/discountable-elements@workspace:libraries/discountable-elements":
+"@decidables/discountable-elements@npm:^0.6.3, @decidables/discountable-elements@workspace:libraries/discountable-elements":
   version: 0.0.0-use.local
   resolution: "@decidables/discountable-elements@workspace:libraries/discountable-elements"
   dependencies:
-    "@decidables/decidables-elements": "npm:^0.5.4"
-    "@decidables/discountable-math": "npm:^0.2.4"
+    "@decidables/decidables-elements": "npm:^0.5.5"
+    "@decidables/discountable-math": "npm:^0.2.5"
     "@lit-labs/motion": "npm:^1.0.9"
     "@observablehq/plot": "npm:^0.6.17"
     bayes.js: "https://github.com/akrawitz/bayes.js.git#commit=c7b091b75f85a86b6a3965a983b31e23d9ef456f"
@@ -1582,7 +1583,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@decidables/discountable-math@npm:^0.2.4, @decidables/discountable-math@workspace:libraries/discountable-math":
+"@decidables/discountable-math@npm:^0.2.5, @decidables/discountable-math@workspace:libraries/discountable-math":
   version: 0.0.0-use.local
   resolution: "@decidables/discountable-math@workspace:libraries/discountable-math"
   dependencies:
@@ -1594,8 +1595,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@decidables/discountable@workspace:sites/discountable"
   dependencies:
-    "@decidables/decidables-site": "npm:^0.6.0"
-    "@decidables/discountable-elements": "npm:^0.6.2"
+    "@decidables/decidables-site": "npm:^0.6.1"
+    "@decidables/discountable-elements": "npm:^0.6.3"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.47.0"
@@ -1607,12 +1608,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@decidables/prospectable-elements@npm:^0.4.4, @decidables/prospectable-elements@workspace:libraries/prospectable-elements":
+"@decidables/prospectable-elements@npm:^0.4.5, @decidables/prospectable-elements@workspace:libraries/prospectable-elements":
   version: 0.0.0-use.local
   resolution: "@decidables/prospectable-elements@workspace:libraries/prospectable-elements"
   dependencies:
-    "@decidables/decidables-elements": "npm:^0.5.4"
-    "@decidables/prospectable-math": "npm:^0.3.4"
+    "@decidables/decidables-elements": "npm:^0.5.5"
+    "@decidables/prospectable-math": "npm:^0.3.5"
     "@lit-labs/motion": "npm:^1.0.9"
     bayes.js: "https://github.com/akrawitz/bayes.js.git#commit=c7b091b75f85a86b6a3965a983b31e23d9ef456f"
     d3: "npm:^7.9.0"
@@ -1622,7 +1623,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@decidables/prospectable-math@npm:^0.3.4, @decidables/prospectable-math@workspace:libraries/prospectable-math":
+"@decidables/prospectable-math@npm:^0.3.5, @decidables/prospectable-math@workspace:libraries/prospectable-math":
   version: 0.0.0-use.local
   resolution: "@decidables/prospectable-math@workspace:libraries/prospectable-math"
   dependencies:
@@ -1634,8 +1635,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@decidables/prospectable@workspace:sites/prospectable"
   dependencies:
-    "@decidables/decidables-site": "npm:^0.6.0"
-    "@decidables/prospectable-elements": "npm:^0.4.4"
+    "@decidables/decidables-site": "npm:^0.6.1"
+    "@decidables/prospectable-elements": "npm:^0.4.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.47.0"
@@ -6391,6 +6392,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-convert@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "color-convert@npm:3.1.3"
+  dependencies:
+    color-name: "npm:^2.0.0"
+  checksum: 10/36b9b99c138f90eb11a28d1ad911054a9facd6cffde4f00dc49a34ebde7cae28454b2285ede64f273b6a8df9c3228b80e4352f4471978fa8b5005fe91341a67b
+  languageName: node
+  linkType: hard
+
 "color-id@npm:^1.1.0":
   version: 1.1.0
   resolution: "color-id@npm:1.1.0"
@@ -6489,12 +6499,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-string@npm:^2.1.3":
+  version: 2.1.4
+  resolution: "color-string@npm:2.1.4"
+  dependencies:
+    color-name: "npm:^2.0.0"
+  checksum: 10/689a8688ac3cd55247792c83a9db9bfe675343c7412fedba1eb748ac6a8867dd2bb3d406e309ebfe90336809ee5067c7f2cccfbd10133c5cc9ef1dba5aad58f2
+  languageName: node
+  linkType: hard
+
 "color-support@npm:1.1.3, color-support@npm:^1.1.3":
   version: 1.1.3
   resolution: "color-support@npm:1.1.3"
   bin:
     color-support: bin.js
   checksum: 10/4bcfe30eea1498fe1cabc852bbda6c9770f230ea0e4faf4611c5858b1b9e4dde3730ac485e65f54ca182f4c50b626c1bea7c8441ceda47367a54a818c248aa7a
+  languageName: node
+  linkType: hard
+
+"color@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "color@npm:5.0.3"
+  dependencies:
+    color-convert: "npm:^3.1.3"
+    color-string: "npm:^2.1.3"
+  checksum: 10/88063ee058b995e5738092b5aa58888666275d1e967333f3814ff4fa334ce9a9e71de78a16fb1838f17c80793ea87f4878c20192037662809fe14eab2d474fd9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
A recent update of SASS lead to the use of floats in `rgb()` colors in CSS. Then
these colors are retrieved in JS and passed to `d3-color` which can't handle
floats in color specs.

In order to properly handle all color values returned from CSS, now using the
`color` package to parse the colors and convert to HEX format safe for `d3-color`.

Fixes #21