### PR TITLE
feat(detectable-elements): added `d3-interpolate-path` for smooth contour transitions in `roc-space`

### DIFF
--- a/libraries/detectable-elements/package.json
+++ b/libraries/detectable-elements/package.json
@@ -58,6 +58,7 @@
     "@decidables/detectable-math": "^0.2.5",
     "color": "^5.0.3",
     "d3": "^7.9.0",
+    "d3-interpolate-path": "^2.3.0",
     "jstat": "^1.9.6",
     "lit": "^3.3.1"
   }

--- a/libraries/detectable-elements/src/components/roc-space.js
+++ b/libraries/detectable-elements/src/components/roc-space.js
@@ -1,6 +1,7 @@
 
 import {css, html, render} from 'lit';
 import * as d3 from 'd3';
+import {interpolatePath} from 'd3-interpolate-path';
 import color from 'color';
 
 import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
@@ -604,8 +605,15 @@ export default class ROCSpace extends DecidablesMixinResizeable(DetectableElemen
         contoursEnter.merge(contoursUpdate).transition()
           .duration(transitionDuration * 2) // Extra long transition!
           .ease(d3.easeCubicOut)
-          .attr('d', d3.geoPath(d3.geoIdentity().scale(width / n))) // ????
+          // .attr('d', d3.geoPath(d3.geoIdentity().scale(width / n))) // ????
+          .attrTween('d', (datum, index, elements) => {
+            const element = elements[index];
+            const previous = d3.select(element).attr('d');
+            const current = d3.geoPath(d3.geoIdentity().scale(width / n))(datum);
+            return interpolatePath(previous, current);
+          })
           .attr('fill', (datum) => { return contourColor(datum.value); });
+
         //  EXIT
         contoursUpdate.exit().remove();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,7 @@ __metadata:
     "@decidables/detectable-math": "npm:^0.2.5"
     color: "npm:^5.0.3"
     d3: "npm:^7.9.0"
+    d3-interpolate-path: "npm:^2.3.0"
     gulp: "npm:^5.0.1"
     jstat: "npm:^1.9.6"
     lit: "npm:^3.3.1"
@@ -7357,6 +7358,13 @@ __metadata:
   version: 1.1.9
   resolution: "d3-hierarchy@npm:1.1.9"
   checksum: 10/d2a4e518c3e35de15e0ac7f0a420300a658435850fc32eaf15b7811697e34565b89012e07e60a53babb723dc43df8981102079b4097b790b42ac21c8d23c0424
+  languageName: node
+  linkType: hard
+
+"d3-interpolate-path@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "d3-interpolate-path@npm:2.3.0"
+  checksum: 10/8f434276dd40253b6099f7339070dcffb95ca3769448e361faab21d59d6b30e8c79d191eebd230eada39962b12aaa39a0e48aded4c6485e7852c18943ad8eda2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #35