### PR TITLE
feat(all): convert equations to MathML

### DIFF
--- a/libraries/accumulable-elements/src/equations/azv2pc.js
+++ b/libraries/accumulable-elements/src/equations/azv2pc.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import DDMMath from '@decidables/accumulable-math';
@@ -86,87 +86,176 @@ export default class DDMEquationAZV2PC extends DDMEquation {
   }
 
   render() {
+    // Hacks for Firefox:
+    // * Wrap <mtext> with HTML in an <mtable><mtr><mtd> to get vertical alignment correct
+    // * <mi> requires `mathvariant="normal"` in addition to `text-transform: none;` in CSS
+    // * Wrap <mn> in <mrow> within <msub> and <msup> to get font-size correct with `font-family`
     let a;
     let z;
     let v;
     let s;
     let accuracy;
     if (this.numeric) {
-      a = html`<decidables-spinner class="a bottom"
-          ?disabled=${!this.interactive}
-          min=${DDMMath.a.MIN}
-          max=${DDMMath.a.MAX}
-          step=${DDMMath.a.STEP}
-          .value=${this.a}
-          @input=${this.aInput.bind(this)}
-        >
-          <var class="math-var">a</var>
-        </decidables-spinner>`;
-      z = html`<decidables-spinner class="z bottom"
-          ?disabled=${!this.interactive}
-          min=${DDMMath.z.MIN}
-          max=${DDMMath.z.MAX}
-          step=${DDMMath.z.STEP}
-          .value=${this.z}
-          @input=${this.zInput.bind(this)}
-        >
-          <var class="math-var">z</var>
-        </decidables-spinner>`;
-      v = html`<decidables-spinner class="v bottom"
-          ?disabled=${!this.interactive}
-          min=${DDMMath.v.MIN}
-          max=${DDMMath.v.MAX}
-          step=${DDMMath.v.STEP}
-          .value=${this.v}
-          @input=${this.vInput.bind(this)}
-        >
-          <var class="math-var">v</var>
-        </decidables-spinner>`;
-      s = html`<decidables-spinner class="s bottom"
-          disabled
-          .value=${DDMMath.s.DEFAULT}
-        >
-          <var class="math-var">s</var>
-        </decidables-spinner>`;
-      accuracy = html`<decidables-spinner class="accuracy bottom"
-          disabled
-          .value=${+this.accuracy.toFixed(2)}
-        >
-          <var>Accuracy</var>
-        </decidables-spinner>`;
+      a = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math a"
+            ?disabled=${!this.interactive}
+            min=${DDMMath.a.MIN}
+            max=${DDMMath.a.MAX}
+            step=${DDMMath.a.STEP}
+            .value=${this.a}
+            @input=${this.aInput.bind(this)}
+          >
+            <var class="math-var">a</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      z = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math z"
+            ?disabled=${!this.interactive}
+            min=${DDMMath.z.MIN}
+            max=${DDMMath.z.MAX}
+            step=${DDMMath.z.STEP}
+            .value=${this.z}
+            @input=${this.zInput.bind(this)}
+          >
+            <var class="math-var">z</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      v = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v"
+            ?disabled=${!this.interactive}
+            min=${DDMMath.v.MIN}
+            max=${DDMMath.v.MAX}
+            step=${DDMMath.v.STEP}
+            .value=${this.v}
+            @input=${this.vInput.bind(this)}
+          >
+            <var class="math-var">v</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      s = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math s"
+            disabled
+            .value=${DDMMath.s.DEFAULT}
+          >
+            <var class="math-var">s</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      accuracy = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math accuracy"
+            disabled
+            .value=${+this.accuracy.toFixed(2)}
+          >
+            <var>Accuracy</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      a = html`<var class="math-var a">a</var>`;
-      z = html`<var class="math-var z">z</var>`;
-      v = html`<var class="math-var v">v</var>`;
-      s = html`<var class="math-var s">s</var>`;
-      accuracy = html`<var class="accuracy">Accuracy</var>`;
+      a = mathml`<mi mathvariant="normal" class="math-id a">a</mi>`;
+      z = mathml`<mi mathvariant="normal" class="math-id z">z</mi>`;
+      v = mathml`<mi mathvariant="normal" class="math-id v">v</mi>`;
+      s = mathml`<mi mathvariant="normal" class="math-id s">s</mi>`;
+      accuracy = mathml`<mtext class="accuracy">Accuracy</mtext>`;
     }
-    const equation = html`
-      <tr>
-        <td rowspan="2">
-          ${accuracy}<span class="equals">=</span>
-        </td>
-        <td class="underline">
-          <var class="math-greek e tight">e</var><sup class="exp"><span class="minus tight">−</span><span class="paren tight">(</span>2${v}${a} / ${s}<sup class="exp">2</sup><span class="paren tight">)</span></sup>
-          <span class="minus">−</span>
-          <var class="math-greek e tight">e</var><sup class="exp"><span class="minus tight">−</span><span class="paren tight">(</span>2${v}${z} / ${s}<sup class="exp">2</sup><span class="paren tight">)</span></sup>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <var class="math-greek e tight">e</var><sup class="exp"><span class="minus tight">−</span><span class="paren tight">(</span>2${v}${a} / ${s}<sup class="exp">2</sup><span class="paren tight">)</span></sup>
-            <span class="minus">−</span>
-          1
-        </td>
-      </tr>`;
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${accuracy}
+            <mo>=</mo>
+            <mfrac>
+              <mrow>
+                <msup>
+                  <mrow>
+                    <mi mathvariant="normal">e</mi>
+                  </mrow>
+                  <mrow>
+                    <mo form="prefix">−</mo>
+                    <mrow>
+                      <mo symmetric="false">(</mo>
+                      <mrow>
+                        <mn>2</mn>
+                        ${v}
+                        ${a}
+                        <mo stretchy="true">⁄</mo>
+                        <msup>
+                          <mrow>
+                            ${s}
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </msup>
+                      </mrow>
+                      <mo symmetric="false">)</mo>
+                    </mrow>
+                  </mrow>
+                </msup>
+                <mo>−</mo>
+                <msup>
+                  <mrow>
+                    <mi mathvariant="normal">e</mi>
+                  </mrow>
+                  <mrow>
+                    <mo form="prefix">−</mo>
+                    <mrow>
+                      <mo symmetric="false">(</mo>
+                      <mrow>
+                        <mn>2</mn>
+                          ${v}
+                          ${z}
+                        <mo stretchy="true">⁄</mo>
+                        <msup>
+                          <mrow>
+                            ${s}
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </msup>
+                      </mrow>
+                      <mo symmetric="false">)</mo>
+                    </mrow>
+                  </mrow>
+                </msup>
+              </mrow>
+              <mrow>
+                <msup>
+                  <mi mathvariant="normal">e</mi>
+                  <mrow>
+                    <mo form="prefix">−</mo>
+                    <mrow>
+                      <mo symmetric="false">(</mo>
+                      <mrow>
+                        <mn>2</mn>
+                        ${v}
+                        ${a}
+                        <mo stretchy="true">⁄</mo>
+                        <msup>
+                          <mrow>
+                            ${s}
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </msup>
+                      </mrow>
+                      <mo symmetric="false">)</mo>
+                    </mrow>
+                  </mrow>
+                </msup>
+                <mo>−</mo>
+                <mn>1</mn>
+              </mrow>
+            </mfrac>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            \\text{Accuracy} = \\frac{e^{-(2va / s^2)} - e^{-(2vz / s^2)}}{e^{-(2va / s^2)} - 1}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            "Accuracy" = (e^-(2va // s^2) - e^-(2vz // s^2)) / (e^-(2va // s^2) - 1)
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/accumulable-elements/src/equations/azvt02m.js
+++ b/libraries/accumulable-elements/src/equations/azvt02m.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import DDMMath from '@decidables/accumulable-math';
@@ -106,110 +106,178 @@ export default class DDMEquationAZVT02M extends DDMEquation {
     let s;
     let meanRT;
     if (this.numeric) {
-      a = html`<decidables-spinner class="a bottom"
-          ?disabled=${!this.interactive}
-          min=${DDMMath.a.MIN}
-          max=${DDMMath.a.MAX}
-          step=${DDMMath.a.STEP}
-          .value=${this.a}
-          @input=${this.aInput.bind(this)}
-        >
-          <var class="math-var">a</var>
-        </decidables-spinner>`;
-      z = html`<decidables-spinner class="z bottom"
-          ?disabled=${!this.interactive}
-          min=${DDMMath.z.MIN}
-          max=${DDMMath.z.MAX}
-          step=${DDMMath.z.STEP}
-          .value=${this.z}
-          @input=${this.zInput.bind(this)}
-        >
-          <var class="math-var">z</var>
-        </decidables-spinner>`;
-      v = html`<decidables-spinner class="v bottom"
-          ?disabled=${!this.interactive}
-          min=${DDMMath.v.MIN}
-          max=${DDMMath.v.MAX}
-          step=${DDMMath.v.STEP}
-          .value=${this.v}
-          @input=${this.vInput.bind(this)}
-        >
-          <var class="math-var">v</var>
-        </decidables-spinner>`;
-      t0 = html`<decidables-spinner class="t0 bottom"
-          ?disabled=${!this.interactive}
-          min=${DDMMath.t0.MIN}
-          max=${DDMMath.t0.MAX}
-          step=${DDMMath.t0.STEP}
-          .value=${this.t0}
-          @input=${this.t0Input.bind(this)}
-        >
-          <var class="math-var">t<sub>0</sub></var>
-        </decidables-spinner>`;
-      s = html`<decidables-spinner class="s bottom"
-          disabled
-          .value=${DDMMath.s.DEFAULT}
-        >
-          <var class="math-var">s</var>
-        </decidables-spinner>`;
-      meanRT = html`<decidables-spinner class="mean-rt bottom"
-          disabled
-          .value=${+this.meanRT.toFixed(0)}
-        >
-          <var>Mean RT</var>
-        </decidables-spinner>`;
+      a = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math a"
+            ?disabled=${!this.interactive}
+            min=${DDMMath.a.MIN}
+            max=${DDMMath.a.MAX}
+            step=${DDMMath.a.STEP}
+            .value=${this.a}
+            @input=${this.aInput.bind(this)}
+          >
+            <var class="math-var">a</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      z = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math z"
+            ?disabled=${!this.interactive}
+            min=${DDMMath.z.MIN}
+            max=${DDMMath.z.MAX}
+            step=${DDMMath.z.STEP}
+            .value=${this.z}
+            @input=${this.zInput.bind(this)}
+          >
+            <var class="math-var">z</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      v = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v"
+            ?disabled=${!this.interactive}
+            min=${DDMMath.v.MIN}
+            max=${DDMMath.v.MAX}
+            step=${DDMMath.v.STEP}
+            .value=${this.v}
+            @input=${this.vInput.bind(this)}
+          >
+            <var class="math-var">v</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      t0 = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math t0"
+            ?disabled=${!this.interactive}
+            min=${DDMMath.t0.MIN}
+            max=${DDMMath.t0.MAX}
+            step=${DDMMath.t0.STEP}
+            .value=${this.t0}
+            @input=${this.t0Input.bind(this)}
+          >
+            <var class="math-var">t<sub class="math-num">0</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      s = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math s"
+            disabled
+            .value=${DDMMath.s.DEFAULT}
+          >
+            <var class="math-var">s</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      meanRT = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math mean-rt"
+            disabled
+            .value=${+this.meanRT.toFixed(0)}
+          >
+            <var>Mean RT</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      a = html`<var class="math-var a">a</var>`;
-      z = html`<var class="math-var z">z</var>`;
-      v = html`<var class="math-var v">v</var>`;
-      t0 = html`<var class="math-var t0">t<sub>0</sub></var>`;
-      s = html`<var class="math-var s">s</var>`;
-      meanRT = html`<var class="mean-rt">Mean RT</var>`;
+      a = mathml`<mi mathvariant="normal" class="math-id a">a</mi>`;
+      z = mathml`<mi mathvariant="normal" class="math-id z">z</mi>`;
+      v = mathml`<mi mathvariant="normal" class="math-id v">v</mi>`;
+      t0 = mathml`<msub class="math-id t0">
+          <mi mathvariant="normal">t</mi>
+          <mrow><mn>0</mn></mrow>
+        </msub>`;
+      s = mathml`<mi mathvariant="normal" class="math-id s">s</mi>`;
+      meanRT = mathml`<mtext class="mean-rt">Mean RT</mtext>`;
     }
-    const equation = html`
-      <tr>
-        <td rowspan="2">
-          ${meanRT}<span class="equals">=</span>
-          ${t0}
-          <span class="minus">−</span>
-        </td>
-        <td class="underline">
-          ${z}
-        </td>
-        <td rowspan="2">
-          <span class="plus">+</span>
-        </td>
-        <td class="underline">
-          ${a}
-        </td>
-        <td rowspan="2">&nbsp;</td>
-        <td class="underline">
-          <var class="math-greek e tight">e</var><sup class="exp"><span class="minus tight">−</span><span class="paren tight">(</span>2${v}${z} / ${s}<sup class="exp">2</sup><span class="paren tight">)</span></sup>
-          <span class="minus">−</span>
-          1
-        </td>
-      </tr>
-      <tr>
-        <td>
-          ${v}
-        </td>
-        <td>
-          ${v}
-        </td>
-        <td>
-          <var class="math-greek e tight">e</var><sup class="exp"><span class="minus tight">−</span><span class="paren tight">(</span>2${v}${a} / ${s}<sup class="exp">2</sup><span class="paren tight">)</span></sup>
-            <span class="minus">−</span>
-          1
-        </td>
-      </tr>`;
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${meanRT}
+            <mo>=</mo>
+            ${t0}
+            <mo>−</mo>
+            <mfrac>
+              <mrow>
+                ${z}
+              </mrow>
+              <mrow>
+                ${v}
+              </mrow>
+            </mfrac>
+            <mo>+</mo>
+            <mfrac>
+              <mrow>
+                ${a}
+              </mrow>
+              <mrow>
+                ${v}
+              </mrow>
+            </mfrac>
+            <mfrac>
+              <mrow>
+                <msup>
+                  <mrow>
+                    <mi mathvariant="normal">e</mi>
+                  </mrow>
+                  <mrow>
+                    <mo form="prefix">−</mo>
+                    <mrow>
+                      <mo symmetric="false">(</mo>
+                      <mrow>
+                        <mn>2</mn>
+                        ${v}
+                        ${z}
+                        <mo stretchy="true">⁄</mo>
+                        <msup>
+                          <mrow>
+                            ${s}
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </msup>
+                      </mrow>
+                      <mo symmetric="false">)</mo>
+                    </mrow>
+                  </mrow>
+                </msup>
+                <mo>−</mo>
+                <mn>1</mn>
+              </mrow>
+              <mrow>
+                <msup>
+                  <mrow>
+                    <mi mathvariant="normal">e</mi>
+                  </mrow>
+                  <mrow>
+                    <mo form="prefix">−</mo>
+                    <mrow>
+                      <mo symmetric="false">(</mo>
+                      <mrow>
+                        <mn>2</mn>
+                        ${v}
+                        ${a}
+                        <mo stretchy="true">⁄</mo>
+                        <msup>
+                          <mrow>
+                            ${s}
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </msup>
+                      </mrow>
+                      <mo symmetric="false">)</mo>
+                    </mrow>
+                  </mrow>
+                </msup>
+                <mo>−</mo>
+                <mn>1</mn>
+              </mrow>
+            </mfrac>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            \\text{Mean RT} = t_0 - \\frac{z}{v} + \\frac{a}{v} \\frac{e^{-(2vz / s^2)} - 1} {e^{-(2va / s^2)} - 1}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            "Mean RT" = t_0 - z / v + a / v (e^-(2vz // s^2) - 1) / (e^-(2va // s^2) - 1)
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/accumulable-elements/src/equations/ddm-equation.js
+++ b/libraries/accumulable-elements/src/equations/ddm-equation.js
@@ -1,174 +1,18 @@
 
 import {css} from 'lit';
 
+import {DecidablesMixinEquation} from '@decidables/decidables-elements';
+
 import AccumulableElement from '../accumulable-element';
 
 /*
   DDMEquation Base Class - Not intended for instantiation!
 */
-export default class DDMEquation extends AccumulableElement {
-  static get properties() {
-    return {
-      numeric: {
-        attribute: 'numeric',
-        type: Boolean,
-        reflect: true,
-      },
-    };
-  }
-
-  constructor() {
-    super();
-    this.numeric = false;
-  }
-
+export default class DDMEquation extends DecidablesMixinEquation(AccumulableElement) {
   static get styles() {
     return [
       super.styles,
       css`
-        :host {
-          display: block;
-
-          margin: 1rem;
-        }
-
-        /* Containing <div> */
-        .holder {
-          display: flex;
-
-          flex-direction: row;
-
-          justify-content: left;
-        }
-
-        /* Overall <table> */
-        .equation {
-          text-align: center;
-          white-space: nowrap;
-
-          border-collapse: collapse;
-
-          border: 0;
-        }
-
-        /* Modifies <td> */
-        .underline {
-          border-bottom: 1px solid var(---color-text);
-        }
-
-        /* Basic <span> and <var> w/modifiers */
-        span,
-        var {
-          padding: 0 0.25rem;
-
-          font-style: normal;
-        }
-
-        var {
-          border-radius: var(---border-radius);
-        }
-
-        .tight {
-          padding: 0;
-        }
-
-        .paren {
-          font-size: 150%;
-        }
-
-        .bracket {
-          font-size: 175%;
-        }
-
-        .brace {
-          font-size: 200%;
-        }
-
-        .addend {
-          position: relative;
-
-          display: inline-block;
-        }
-
-        .comparison {
-          position: relative;
-
-          display: inline-block;
-
-          font-size: 125%;
-          font-weight: 600;
-        }
-
-        .function {
-          display: inline-block;
-
-          border-radius: var(---border-radius);
-        }
-
-        :host([numeric]) .function {
-          padding: 0.25rem;
-        }
-
-        .exp {
-          display: inline-block;
-
-          font-size: 0.75rem;
-        }
-
-        .subscript {
-          display: inline-block;
-
-          font-size: 66.667%;
-        }
-
-        .summation {
-          display: flex;
-
-          flex-direction: column;
-
-          line-height: 0.8;
-        }
-
-        .sigma {
-          display: inline-block;
-
-          font-size: 200%;
-        }
-
-        /* Input wrapping <label> */
-        decidables-spinner {
-          --decidables-spinner-input-width: 4rem;
-
-          display: inline-block;
-
-          padding: 0.125rem 0.375rem 0.375rem;
-
-          line-height: 1.5;
-          vertical-align: middle;
-
-          border-radius: var(---border-radius);
-        }
-
-        .n {
-          --decidables-spinner-input-width: 2rem;
-        }
-
-        .left {
-          text-align: left;
-        }
-
-        .right {
-          text-align: right;
-        }
-
-        .bottom {
-          vertical-align: bottom;
-        }
-
-        .top {
-          vertical-align: top;
-        }
-
         /* Color scheme */
         .a {
           background: var(---color-a-light);

--- a/libraries/accumulable-elements/test/equations/azv2pc.test.js
+++ b/libraries/accumulable-elements/test/equations/azv2pc.test.js
@@ -13,7 +13,7 @@ import '../../src/equations/azv2pc';
 describe('ddm-equation-azv2pc', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<ddm-equation-azv2pc></ddm-equation-azv2pc>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/accumulable-elements/test/equations/azvt02m.test.js
+++ b/libraries/accumulable-elements/test/equations/azvt02m.test.js
@@ -13,7 +13,7 @@ import '../../src/equations/azvt02m';
 describe('ddm-equation-azvt02m', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<ddm-equation-azvt02m></ddm-equation-azvt02m>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/decidables-elements/src/decidables-element.js
+++ b/libraries/decidables-elements/src/decidables-element.js
@@ -172,7 +172,7 @@ export default class DecidablesElement extends LitElement {
         ---color-element-emphasis: var(--color-element-emphasis, ${unsafeCSS(this.greys.dark75)});
 
         ---font-family-base: var(--font-family-base, "Source Sans", sans-serif);
-        ---font-family-math: var(--font-family-math, "Source Serif", serif);
+        ---font-family-symbol: var(--font-family-symbol, "Source Serif", serif);
 
         ---border: var(--border, 1px solid var(---color-border));
         ---border-radius: var(--border-radius, 0.25rem);
@@ -190,7 +190,7 @@ export default class DecidablesElement extends LitElement {
       }
 
       .math-greek {
-        font-family: var(---font-family-math);
+        font-family: var(---font-family-symbol);
         font-style: normal;
       }
 
@@ -199,8 +199,13 @@ export default class DecidablesElement extends LitElement {
         font-style: normal;
       }
 
+      .math-text {
+        font-family: var(---font-family-base);
+        font-style: normal;
+      }
+
       .math-var {
-        font-family: var(---font-family-math);
+        font-family: var(---font-family-symbol);
         font-style: italic;
       }
 

--- a/libraries/decidables-elements/src/index.js
+++ b/libraries/decidables-elements/src/index.js
@@ -15,4 +15,5 @@ export {default as DecidablesConverterArray} from './converter-array';
 export {default as DecidablesConverterSet} from './converter-set';
 
 // Mixins
+export {default as DecidablesMixinEquation} from './mixin-equation';
 export {default as DecidablesMixinResizeable} from './mixin-resizeable';

--- a/libraries/decidables-elements/src/mixin-equation.js
+++ b/libraries/decidables-elements/src/mixin-equation.js
@@ -1,0 +1,167 @@
+import {css} from 'lit';
+
+export default function DecidablesMixinEquation(superClass) {
+  return class extends superClass {
+    static get properties() {
+      return {
+        numeric: {
+          attribute: 'numeric',
+          type: Boolean,
+          reflect: true,
+        },
+      };
+    }
+
+    constructor() {
+      super();
+
+      this.numeric = false;
+    }
+
+    static get styles() {
+      return [
+        super.styles,
+        css`
+          :host {
+            ---font-family-math: var(--font-family-math, "DejaVu Math", math);
+
+            display: block;
+
+            margin: 1rem;
+          }
+
+          /* Containing <div> */
+          .holder {
+            display: flex;
+
+            flex-direction: row;
+
+            justify-content: left;
+          }
+
+          /* MathML */
+          .math-id {
+            padding: 0.25rem;
+
+            border-radius: var(---border-radius);
+          }
+
+          /* Different bounding box in Firefox */
+          @supports (-moz-appearance: textfield) {
+            .math-id {
+              padding: 0 0.25rem;
+            }
+
+            /* Avoid excessive float above fraction line */
+            /* Target mrow on top of mfrac with mtext or mi in it */
+            /* stylelint-disable-next-line selector-max-compound-selectors */
+            mfrac > mrow:first-child:has(> mtable, > msup > mrow > mtable) {
+              transform: translateY(0.375rem);
+            }
+
+            /* Avoid bounding box overlapping fraction line */
+            /* Target mrow on top of mfrac with mtext or mi in it */
+            /* stylelint-disable-next-line selector-max-compound-selectors */
+            mfrac > mrow:first-child:has(> mtext, > mi, > msup > mrow > mi) {
+              transform: translateY(-0.125rem);
+            }
+
+            /* Avoid bounding box overlapping fraction line */
+            /* Target mrow on bottom of mfrac with mtext or mi in it */
+            /* stylelint-disable-next-line selector-max-compound-selectors */
+            mfrac > mrow + mrow:has(> mtext, > mi) {
+              transform: translateY(0.25rem);
+            }
+
+          }
+
+          math {
+            font-family: var(---font-family-math);
+          }
+
+          mi {
+            font-family: var(---font-family-symbol);
+            font-style: italic;
+
+            text-transform: none;
+          }
+
+          mn {
+            font-family: var(---font-family-base);
+          }
+
+          mtext {
+            font-family: var(---font-family-base);
+          }
+
+          mtable {
+            display: table;
+          }
+
+          mtable mtable {
+            display: inline-table;
+          }
+
+          mtd {
+            padding: 0;
+          }
+
+          .layout > mtr > mtd {
+            padding: 0.125rem;
+            
+            vertical-align: middle;          
+          }
+
+          .leftside {
+            text-align: -webkit-right;
+          }
+
+          /* Different in Safari */
+          @supports (-webkit-hyphens:none) {
+            .leftside {
+              text-align: right;
+            }
+          }
+
+          .rightside {
+            text-align: left;
+          }
+
+          /* Basic <var> w/modifiers */
+          var {
+            padding: 0 0.25rem;
+
+            font-style: normal;
+
+            border-radius: var(---border-radius);
+          }
+
+          /* Different bounding box in Safari */
+          @supports (-webkit-hyphens:none) {
+            var {
+              padding: 0.25rem;
+            }
+          }
+
+          /* Input wrapping <label> */
+          decidables-spinner {
+            --decidables-spinner-input-width: 4rem;
+
+            display: inline-block;
+
+            padding: 0.125rem 0.375rem 0.375rem;
+
+            line-height: 1.5;
+            vertical-align: middle;
+
+            border-radius: var(---border-radius);
+          }
+
+          .sum-over {
+            --decidables-spinner-input-width: 2rem;
+          }
+        `,
+      ];
+    }
+  };
+}

--- a/libraries/decidables-elements/src/spinner.js
+++ b/libraries/decidables-elements/src/spinner.js
@@ -149,6 +149,16 @@ export default class DecidablesSpinner extends DecidablesElement {
             appearance: textfield;
           }
 
+          /* HACK: Avoid elements shifting due to box-shadow! */
+          :host(.math) input[type=number]:hover {
+            box-shadow: var(---shadow-2);
+          }
+
+          :host(.math) input[type=number]:focus,
+          :host(.math) input[type=number]:active {
+            box-shadow: var(---shadow-8);
+          }
+
           input[type=number]:hover,
           input[type=number]:focus,
           input[type=number]:active {

--- a/libraries/decidables-site/src/_content.scss
+++ b/libraries/decidables-site/src/_content.scss
@@ -34,13 +34,13 @@
 
   // Math
   .math-var {
-    font-family: $font-family-math;
+    font-family: $font-family-symbol;
     font-style: italic;
     font-variant: normal;
   }
 
   .math-greek {
-    font-family: $font-family-math;
+    font-family: $font-family-symbol;
     font-style: normal;
   }
 

--- a/libraries/decidables-site/src/_fonts.scss
+++ b/libraries/decidables-site/src/_fonts.scss
@@ -13,9 +13,10 @@
 $font-map: $fonts !default;
 
 $font-family-map: (
-  serif: (serif),
-  sans-serif: (sans-serif),
+  math: (math),
   monospace: (monospace),
+  sans-serif: (sans-serif),
+  serif: (serif),
 );
 
 $font-weight-catalog: (
@@ -110,24 +111,26 @@ $font-weight-map: ();
 }
 
 // SASS Variables
-$font-family-serif: map.get($font-family-map, serif); // Not in Bootstrap
-$font-family-sans-serif: map.get($font-family-map, sans-serif);
+$font-family-math: map.get($font-family-map, math); // Not in Bootstrap
 $font-family-monospace: map.get($font-family-map, monospace);
+$font-family-sans-serif: map.get($font-family-map, sans-serif);
+$font-family-serif: map.get($font-family-map, serif); // Not in Bootstrap
 
 $font-family-base: $font-family-sans-serif;
 $font-family-code: $font-family-monospace;
-$font-family-math: $font-family-serif; // Not in Bootstrap
+$font-family-symbol: $font-family-serif;
 
 $font-size-main: 1.125rem; // Not in Bootstrap
 
 // CSS Variables
 :root { /* stylelint-disable-line no-duplicate-selectors */
   --font-family-base: #{meta.inspect($font-family-base)};
-  --font-family-math: #{meta.inspect($font-family-math)};
   --font-family-code: #{meta.inspect($font-family-code)};
-  --font-family-serif: #{meta.inspect($font-family-serif)};
-  --font-family-sans-serif: #{meta.inspect($font-family-sans-serif)};
+  --font-family-math: #{meta.inspect($font-family-math)};
   --font-family-monospace: #{meta.inspect($font-family-monospace)};
+  --font-family-sans-serif: #{meta.inspect($font-family-sans-serif)};
+  --font-family-serif: #{meta.inspect($font-family-serif)};
+  --font-family-symbol: #{meta.inspect($font-family-symbol)};
 }
 
 // Bootstrap Utility
@@ -136,9 +139,10 @@ $utilities: (
     property: font-family,
     class: font,
     values: (
-      serif: var(--font-family-serif),
-      sans-serif: var(--font-family-sans-serif),
+      math: var(--font-family-math),
       monospace: var(--font-family-monospace),
+      sans-serif: var(--font-family-sans-serif),
+      serif: var(--font-family-serif),
     ),
   ),
   "font-weight": (

--- a/libraries/decidables-site/src/fonts.yml
+++ b/libraries/decidables-site/src/fonts.yml
@@ -9,6 +9,15 @@ fonts:
   #   },
   # }
 
+  # DejaVu Math
+  dejavu-math-latin-400-normal: {
+    category: math, package: '@fontsource/dejavu-math', family: DejaVu Math,
+    style: normal, weight-name: normal, weight: 400, stretch: normal,
+    formats: {
+      woff2: {path: files/, extension: woff2},
+    },
+  }
+
   # Source Code Pro
   SourceCodePro-Regular: {
     category: monospace, package: source-code-pro, family: Source Code,

--- a/libraries/detectable-elements/src/equations/dc2far.js
+++ b/libraries/detectable-elements/src/equations/dc2far.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import SDTMath from '@decidables/detectable-math';
@@ -98,108 +98,151 @@ export default class SDTEquationDC2Far extends SDTEquation {
     let s;
     let far;
     if (this.numeric) {
-      d = html`
-        <decidables-spinner class="d bottom" 
-          ?disabled=${!this.interactive}
-          step=${SDTMath.d.STEP}
-          .value=${this.d}
-          @input=${this.dInput.bind(this)}
-        >
-          <var class="math-var">d′</var>
-        </decidables-spinner>
-      `;
-      c = html`
-        <decidables-spinner class="c bottom"
-          ?disabled=${!this.interactive}
-          step=${SDTMath.c.DEFAULT}
-          .value=${this.c}
-          @input=${this.cInput.bind(this)}
-        >
-          <var class="math-var">c</var>
-        </decidables-spinner>
-      `;
-      s = html`
-        <decidables-spinner class="s bottom"
-          ?disabled=${!this.interactive}
-          min=${SDTMath.s.MIN}
-          step=${SDTMath.s.STEP}
-          .value=${this.s}
-          @input=${this.sInput.bind(this)}
-        >
-          <var class="math-var">σ</var>
-        </decidables-spinner>
-      `;
-      far = html`
-        <decidables-spinner class="far bottom"
-          disabled min="0"
-          max="1"
-          step=".001"
-          .value=${+this.far.toFixed(3)}
-        >
-          <var>False Alarm Rate</var>
-        </decidables-spinner>
-      `;
+      d = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math d"
+            ?disabled=${!this.interactive}
+            step=${SDTMath.d.STEP}
+            .value=${this.d}
+            @input=${this.dInput.bind(this)}
+          >
+            <var class="math-var">d′</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      c = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math c"
+            ?disabled=${!this.interactive}
+            step=${SDTMath.c.STEP}
+            .value=${this.c}
+            @input=${this.cInput.bind(this)}
+          >
+            <var class="math-var">c</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      s = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math s"
+            ?disabled=${!this.interactive}
+            min=${SDTMath.s.MIN}
+            step=${SDTMath.s.STEP}
+            .value=${this.s}
+            @input=${this.sInput.bind(this)}
+          >
+            <var class="math-var">σ</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      far = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math far"
+            disabled
+            min="0"
+            max="1"
+            step=".001"
+            .value=${+this.far.toFixed(3)}
+          >
+            <var>False Alarm Rate</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      d = html`<var class="math-var d">d′</var>`;
-      c = html`<var class="math-var c">c</var>`;
-      s = html`<var class="math-var s">σ</var>`;
-      far = html`<var class="far">False Alarm Rate</var>`;
+      d = mathml`<mi mathvariant="normal" class="math-id d">d′</mi>`;
+      c = mathml`<mi mathvariant="normal" class="math-id c">c</mi>`;
+      s = mathml`<mi mathvariant="normal" class="math-id s">σ</mi>`;
+      far = mathml`<mtext class="math-id far">False Alarm Rate</mtext>`;
     }
-    let equation;
-    if (this.unequal) {
-      equation = html`
-        <tr>
-          <td rowspan="2">
-            ${far}<span class="equals">=</span><var class="math-greek phi tight">Φ</var><span class="paren tight">(</span><span class="bracket tight">[</span>
-          </td>
-          <td class="underline bottom">
-            <span>1</span><span class="plus tight">+</span><span>${s}<sup class="exp">2</sup></span>
-          </td>
-          <td rowspan="2">
-            <span class="bracket tight">]<sup class="exp">½</sup></span><span class="bracket tight">[</span>
-          </td>
-          <td class="underline">
-            <span class="minus tight">−</span>${d}
-          </td>
-          <td rowspan="2">
-            <span class="minus">−</span>${c}<span class="bracket tight">]</span><span class="paren tight">)</span>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <span>2</span>
-          </td>
-          <td>
-            <span><span>1</span><span class="plus">+</span>${s}</span>
-          </td>
-        </tr>`;
-    } else {
-      equation = html`
-        <tr>
-          <td rowspan="2">
-            ${far}<span class="equals">=</span><var class="math-greek phi tight">Φ</var><span class="paren tight">(</span><span class="minus tight">−</span>
-          </td>
-          <td class="underline">
-            ${d}
-          </td>
-          <td rowspan="2">
-            <span class="minus">−</span>${c}<span class="paren tight">)</span>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <span>2</span>
-          </td>
-        </tr>`;
-    }
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${far}
+            <mo>=</mo>
+            <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+            <mrow>
+              <mo symmetric="false">(</mo>
+              <mrow>
+                ${this.unequal
+                  ? mathml`
+                    <msup>
+                      <mrow>
+                        <mo symmetric="true">[</mo>
+                        <mfrac>
+                          <mrow>
+                            <mn>1</mn>
+                            <mo>+</mo>
+                            <msup>
+                              <mrow>
+                                ${s}
+                              </mrow>
+                              <mrow>
+                                <mn>2</mn>
+                              </mrow>
+                            </msup>
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </mfrac>
+                        <mo symmetric="true">]</mo>
+                      </mrow>
+                      <mfrac>
+                        <mrow>
+                          <mn>1</mn>
+                        </mrow>
+                        <mrow>
+                          <mn>2</mn>
+                        </mrow>
+                      </mfrac>
+                    </msup>
+                    <mrow>
+                      <mo symmetric="true">[</mo>
+                      <mrow>
+                        <mfrac>
+                          <mrow>
+                            <mo form="prefix">−</mo>
+                            ${d}
+                          </mrow>
+                          <mrow>
+                            <mn>1</mn>
+                            <mo>+</mo>
+                            ${s}
+                          </mrow>
+                        </mfrac>
+                        <mo>−</mo>
+                        ${c}
+                      </mrow>
+                      <mo symmetric="true">]</mo>
+                    </mrow>
+                  `
+                  : mathml`
+                    <mo form="prefix">−</mo>
+                    <mfrac>
+                      <mrow>
+                        ${d}
+                      </mrow>
+                      <mrow>
+                        <mn>2</mn>
+                      </mrow>
+                    </mfrac>
+                    <mo>−</mo>
+                    ${c}
+                  `
+                }
+              </mrow>
+              <mo symmetric="false">)</mo>
+            </mrow>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            ${this.unequal
+              ? mathml`\\text{False Alarm Rate} = \\Phi{\\left({\\left[\\frac{1 + \\sigma^2}{2}\\right]}^{\\frac{1}{2}}
+                  {\\left[\\frac{-d'}{1 + \\sigma} - c\\right]}\\right)}`
+              : mathml`\\text{False Alarm Rate} = \\Phi(-\\frac{d'}{2} - c)`
+            }
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            ${this.unequal
+              ? mathml`"False Alarm Rate" = Phi([(1 + sigma^2) / 2]^(1/2)[(-d') / (1 + sigma) - c])`
+              : mathml`"False Alarm Rate" = Phi(-(d') / 2 - c)`
+            }
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/detectable-elements/src/equations/dc2hr.js
+++ b/libraries/detectable-elements/src/equations/dc2hr.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import SDTMath from '@decidables/detectable-math';
@@ -98,118 +98,156 @@ export default class SDTEquationDC2Hr extends SDTEquation {
     let s;
     let hr;
     if (this.numeric) {
-      d = html`
-        <decidables-spinner class="d bottom"
-          ?disabled=${!this.interactive}
-          step=${SDTMath.d.STEP}
-          .value=${this.d}
-          @input=${this.dInput.bind(this)}
-        >
-          <var class="math-var">d′</var>
-        </decidables-spinner>
-      `;
-      c = html`
-        <decidables-spinner class="c bottom"
-          ?disabled=${!this.interactive}
-          step=${SDTMath.c.STEP}
-          .value=${this.c}
-          @input=${this.cInput.bind(this)}
-        >
-          <var class="math-var">c</var>
-        </decidables-spinner>
-      `;
-      s = html`
-        <decidables-spinner class="s bottom"
-          ?disabled=${!this.interactive}
-          min=${SDTMath.s.MIN}
-          step=${SDTMath.s.STEP}
-          .value=${this.s}
-          @input=${this.sInput.bind(this)}
-        >
-          <var class="math-var">σ</var>
-        </decidables-spinner>
-      `;
-      hr = html`
-        <decidables-spinner class="hr bottom"
-          disabled
-          min="0"
-          max="1"
-          step=".001"
-          .value=${+this.hr.toFixed(3)}
-        >
-          <var>Hit Rate</var>
-        </decidables-spinner>
-      `;
+      d = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math d"
+            ?disabled=${!this.interactive}
+            step=${SDTMath.d.STEP}
+            .value=${this.d}
+            @input=${this.dInput.bind(this)}
+          >
+            <var class="math-var">d′</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      c = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math c"
+            ?disabled=${!this.interactive}
+            step=${SDTMath.c.STEP}
+            .value=${this.c}
+            @input=${this.cInput.bind(this)}
+          >
+            <var class="math-var">c</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      s = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math s"
+            ?disabled=${!this.interactive}
+            min=${SDTMath.s.MIN}
+            step=${SDTMath.s.STEP}
+            .value=${this.s}
+            @input=${this.sInput.bind(this)}
+          >
+            <var class="math-var">σ</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      hr = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math hr"
+            disabled
+            min="0"
+            max="1"
+            step=".001"
+            .value=${+this.hr.toFixed(3)}
+          >
+            <var>Hit Rate</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      d = html`<var class="math-var d">d′</var>`;
-      c = html`<var class="math-var c">c</var>`;
-      s = html`<var class="math-var s">σ</var>`;
-      hr = html`<var class="hr">Hit Rate</var>`;
+      d = mathml`<mi mathvariant="normal" class="math-id d">d′</mi>`;
+      c = mathml`<mi mathvariant="normal" class="math-id c">c</mi>`;
+      s = mathml`<mi mathvariant="normal" class="math-id s">σ</mi>`;
+      hr = mathml`<mtext class="math-id hr">Hit Rate</mtext>`;
     }
-    let equation;
-    if (this.unequal) {
-      equation = html`
-        <tr>
-          <td rowspan="2">
-            ${hr}<span class="equals">=</span><var class="math-greek phi tight">Φ</var><span class="paren tight">(</span><span class="bracket tight">[</span>
-          </td>
-          <td class="underline bottom">
-            <span>1</span><span class="plus tight">+</span><span>${s}<sup class="exp">2</sup></span>
-          </td>
-          <td rowspan="2">
-            <span class="bracket tight">]<sup class="exp">½</sup></span><span class="bracket tight">[</span>
-          </td>
-          <td class="underline">
-            ${d}
-          </td>
-          <td rowspan="2">
-            <span class="minus">−</span>
-          </td>
-          <td class="underline">
-            ${c}
-          </td>
-          <td rowspan="2">
-            <span class="bracket tight">]</span><span class="paren tight">)</span>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <span>2</span>
-          </td>
-          <td>
-            <span><span>1</span><span class="plus">+</span>${s}</span>
-          </td>
-          <td>
-            ${s}
-          </td>
-        </tr>`;
-    } else {
-      equation = html`
-        <tr>
-          <td rowspan="2">
-            ${hr}<span class="equals">=</span><var class="math-greek phi tight">Φ</var><span class="paren tight">(</span>
-          </td>
-          <td class="underline">
-            ${d}
-          </td>
-          <td rowspan="2">
-            <span class="minus">−</span>${c}<span class="paren tight">)</span>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <span>2</span>
-          </td>
-        </tr>`;
-    }
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${hr}
+            <mo>=</mo>
+            <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+            <mrow>
+              <mo symmetric="false">(</mo>
+              <mrow>
+                ${this.unequal
+                  ? mathml`
+                    <msup>
+                      <mrow>
+                        <mo symmetric="true">[</mo>
+                        <mfrac>
+                          <mrow>
+                            <mn>1</mn>
+                            <mo>+</mo>
+                            <msup>
+                              <mrow>
+                                ${s}
+                              </mrow>
+                              <mrow>
+                                <mn>2</mn>
+                              </mrow>
+                            </msup>
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </mfrac>
+                        <mo symmetric="true">]</mo>
+                      </mrow>
+                      <mfrac>
+                        <mrow>
+                          <mn>1</mn>
+                        </mrow>
+                        <mrow>
+                          <mn>2</mn>
+                        </mrow>
+                      </mfrac>
+                    </msup>
+                    <mrow>
+                      <mo symmetric="true">[</mo>
+                      <mrow>
+                        <mfrac>
+                          <mrow>
+                            ${d}
+                          </mrow>
+                          <mrow>
+                              <mn>1</mn>
+                              <mo>+</mo>
+                              ${s}
+                          </mrow>
+                        </mfrac>
+                        <mo>−</mo>
+                        <mfrac>
+                          <mrow>
+                            ${c}
+                          </mrow>
+                          <mrow>
+                            ${s}
+                          </mrow>
+                        </mfrac>
+                      </mrow>
+                      <mo symmetric="true">]</mo>
+                    </mrow>
+                  `
+                  : mathml`
+                    <mfrac>
+                      <mrow>
+                        ${d}
+                      </mrow>
+                      <mrow>
+                        <mn>2</mn>
+                      </mrow>
+                    </mfrac>
+                    <mo>−</mo>
+                    ${c}
+                  `
+                }
+              </mrow>
+              <mo symmetric="false">)</mo>
+            </mrow>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            ${this.unequal
+              ? mathml`\\text{Hit Rate} = \\Phi{\\left({\\left[\\frac{1 + \\sigma^2}{2}\\right]}^{\\frac{1}{2}}
+                  {\\left[\\frac{d'}{1 + \\sigma} - \\frac{c}{\\sigma}\\right]}\\right)}`
+              : mathml`\\text{Hit Rate} = \\Phi(\\frac{d'}{2} - c)`
+            }
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            ${this.unequal
+              ? mathml`"Hit Rate" = Phi([(1 + sigma^2) / 2]^(1/2)[(d') / (1 + sigma) - c / sigma])`
+              : mathml`"Hit Rate" = Phi((d') / 2 - c)`
+            }
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/detectable-elements/src/equations/facr2far.js
+++ b/libraries/detectable-elements/src/equations/facr2far.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import SDTMath from '@decidables/detectable-math';
@@ -77,62 +77,69 @@ export default class SDTEquationFaCr2Far extends SDTEquation {
     let cr;
     let far;
     if (this.numeric) {
-      fa = html`
-        <decidables-spinner class="fa"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.fa}
-          @input=${this.faInput.bind(this)}
-        >
-          <var>False Alarms</var>
-        </decidables-spinner>
-      `;
-      cr = html`
-        <decidables-spinner class="cr"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.cr}
-          @input=${this.crInput.bind(this)}
-        >
-          <var>Correct Rejections</var>
-        </decidables-spinner>
-      `;
-      far = html`
-        <decidables-spinner class="far"
-          disabled
-          min="0"
-          max="1"
-          step=".001"
-          .value=${+this.far.toFixed(3)}
-        >
-          <var>False Alarm Rate</var>
-        </decidables-spinner>
-      `;
+      fa = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math fa"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.fa}
+            @input=${this.faInput.bind(this)}
+          >
+            <var>False Alarms</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      cr = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math cr"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.cr}
+            @input=${this.crInput.bind(this)}
+          >
+            <var>Correct Rejections</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      far = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math far"
+            disabled
+            min="0"
+            max="1"
+            step=".001"
+            .value=${+this.far.toFixed(3)}
+          >
+            <var>False Alarm Rate</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      fa = html`<var class="fa">False Alarms</var>`;
-      cr = html`<var class="cr">Correct Rejections</var>`;
-      far = html`<var class="far">False Alarm Rate</var>`;
+      fa = mathml`<mtext class="math-id fa">False Alarms</mtext>`;
+      cr = mathml`<mtext class="math-id cr">Correct Rejections</mtext>`;
+      far = mathml`<mtext class="math-id far">False Alarm Rate</mtext>`;
     }
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            <tr>
-              <td rowspan="2">
-                ${far}<span class="equals">=</span>
-              </td>
-              <td class="underline">
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${far}
+            <mo>=</mo>
+            <mfrac>
+              <mrow>
                 ${fa}
-              </td>
-            </tr>
-            <tr>
-              <td>
-                ${fa}<span class="plus">+</span>${cr}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>`;
+              </mrow>
+              <mrow>
+                ${fa}
+                <mo>+</mo>
+                ${cr}
+              </mrow>
+            </mfrac>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            \\text{False Alarm Rate} = \\frac{\\text{False Alarms}}
+              {\\text{False Alarms} + \\text{Correct Rejections}}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            "False Alarm Rate" = "False Alarms" / ("False Alarms" + "Correct Rejections")
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/detectable-elements/src/equations/hfa2ppv.js
+++ b/libraries/detectable-elements/src/equations/hfa2ppv.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import SDTMath from '@decidables/detectable-math';
@@ -77,63 +77,69 @@ export default class SDTEquationHFa2Ppv extends SDTEquation {
     let fa;
     let ppv;
     if (this.numeric) {
-      h = html`
-        <decidables-spinner class="h"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.h}
-          @input=${this.hInput.bind(this)}
-        >
-          <var>Hits</var>
-        </decidables-spinner>
-      `;
-      fa = html`
-        <decidables-spinner class="fa"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.fa}
-          @input=${this.faInput.bind(this)}
-        >
-          <var>False Alarms</var>
-        </decidables-spinner>
-      `;
-      ppv = html`
-        <decidables-spinner class="ppv"
-          disabled
-          min="0"
-          max="1"
-          step=".001"
-          .value=${+this.ppv.toFixed(3)}
-        >
-          <var>Positive Predictive Value</var>
-        </decidables-spinner>
-      `;
+      h = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math h"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.h}
+            @input=${this.hInput.bind(this)}
+          >
+            <var>Hits</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      fa = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math fa"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.fa}
+            @input=${this.faInput.bind(this)}
+          >
+            <var>False Alarms</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      ppv = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math ppv"
+            disabled
+            min="0"
+            max="1"
+            step=".001"
+            .value=${+this.ppv.toFixed(3)}
+          >
+            <var>Positive Predictive Value</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      h = html`<var class="h">Hits</var>`;
-      fa = html`<var class="fa">False Alarms</var>`;
-      ppv = html`<var class="ppv">Positive Predictive Value</var>`;
+      h = mathml`<mtext class="math-id h">Hits</mtext>`;
+      fa = mathml`<mtext class="math-id fa">False Alarms</mtext>`;
+      ppv = mathml`<mtext class="math-id ppv">Positive Predictive Value</mtext>`;
     }
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            <tr>
-              <td rowspan="2">
-                ${ppv}<span class="equals">=</span>
-              </td>
-              <td class="underline">
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${ppv}
+            <mo>=</mo>
+            <mfrac>
+              <mrow>
                 ${h}
-              </td>
-            </tr>
-            <tr>
-              <td>
-                ${h}<span class="plus">+</span>${fa}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    `;
+              </mrow>
+              <mrow>
+                ${h}
+                <mo>+</mo>
+                ${fa}
+              </mrow>
+            </mfrac>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            \\text{Positive Predictive Value} = \\frac{\\text{Hits}}
+              {\\text{Hits} + \\text{False Alarms}}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            "Positive Predictive Value" = "Hits" / ("Hits" + "False Alarms")
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/detectable-elements/src/equations/hm2hr.js
+++ b/libraries/detectable-elements/src/equations/hm2hr.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import SDTMath from '@decidables/detectable-math';
@@ -77,63 +77,68 @@ export default class SDTEquationHM2Hr extends SDTEquation {
     let m;
     let hr;
     if (this.numeric) {
-      h = html`
-        <decidables-spinner class="h"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.h}
-          @input=${this.hInput.bind(this)}
-        >
-          <var>Hits</var>
-        </decidables-spinner>
-      `;
-      m = html`
-        <decidables-spinner class="m"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.m}
-          @input=${this.mInput.bind(this)}
-        >
-          <var>Misses</var>
-        </decidables-spinner>
-      `;
-      hr = html`
-        <decidables-spinner class="hr"
-          disabled
-          min="0"
-          max="1"
-          step=".001"
-          .value=${+this.hr.toFixed(3)}
-        >
-          <var>Hit Rate</var>
-        </decidables-spinner>
-      `;
+      h = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math h"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.h}
+            @input=${this.hInput.bind(this)}
+          >
+            <var>Hits</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      m = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math m"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.m}
+            @input=${this.mInput.bind(this)}
+          >
+            <var>Misses</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      hr = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math hr"
+            disabled
+            min="0"
+            max="1"
+            step=".001"
+            .value=${+this.hr.toFixed(3)}
+          >
+            <var>Hit Rate</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      h = html`<var class="h">Hits</var>`;
-      m = html`<var class="m">Misses</var>`;
-      hr = html`<var class="hr">Hit Rate</var>`;
+      h = mathml`<mtext class="math-id h">Hits</mtext>`;
+      m = mathml`<mtext class="math-id m">Misses</mtext>`;
+      hr = mathml`<mtext class="math-id hr">Hit Rate</mtext>`;
     }
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            <tr>
-              <td rowspan="2">
-                ${hr}<span class="equals">=</span>
-              </td>
-              <td class="underline">
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${hr}
+            <mo>=</mo>
+            <mfrac>
+              <mrow>
                 ${h}
-              </td>
-            </tr>
-            <tr>
-              <td>
-                ${h}<span class="plus">+</span>${m}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    `;
+              </mrow>
+              <mrow>
+                ${h}
+                <mo>+</mo>
+                ${m}
+              </mrow>
+            </mfrac>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            \\text{Hit Rate} = \\frac{\\text{Hits}}{\\text{Hits} + \\text{Misses}}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            "Hit Rate" = "Hits" / ("Hits" + "Misses")
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/detectable-elements/src/equations/hmfacr2acc.js
+++ b/libraries/detectable-elements/src/equations/hmfacr2acc.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import SDTMath from '@decidables/detectable-math';
@@ -106,84 +106,98 @@ export default class SDTEquationHMFaCr2Acc extends SDTEquation {
     let acc;
 
     if (this.numeric) {
-      h = html`
-        <decidables-spinner class="h"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.h}
-          @input=${this.hInput.bind(this)}
-        >
-          <var>Hits</var>
-        </decidables-spinner>
-      `;
-      m = html`
-        <decidables-spinner class="m"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.m}
-          @input=${this.mInput.bind(this)}
-        >
-          <var>Misses</var>
-        </decidables-spinner>
-      `;
-      fa = html`
-        <decidables-spinner class="fa"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.fa}
-          @input=${this.faInput.bind(this)}
-        >
-          <var>False Alarms</var>
-        </decidables-spinner>
-      `;
-      cr = html`
-        <decidables-spinner class="cr"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.cr}
-          @input=${this.crInput.bind(this)}
-        >
-          <var>Correct Rejections</var>
-        </decidables-spinner>
-      `;
-      acc = html`
-        <decidables-spinner class="acc"
-          disabled
-          min="0"
-          max="1"
-          step=".001"
-          .value=${+this.acc.toFixed(3)}
-        >
-          <var>Accuracy</var>
-        </decidables-spinner>
-      `;
+      h = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math h"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.h}
+            @input=${this.hInput.bind(this)}
+          >
+            <var>Hits</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      m = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math m"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.m}
+            @input=${this.mInput.bind(this)}
+          >
+            <var>Misses</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      fa = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math fa"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.fa}
+            @input=${this.faInput.bind(this)}
+          >
+            <var>False Alarms</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      cr = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math cr"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.cr}
+            @input=${this.crInput.bind(this)}
+          >
+            <var>Correct Rejections</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      acc = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math acc"
+            disabled
+            min="0"
+            max="1"
+            step=".001"
+            .value=${+this.acc.toFixed(3)}
+          >
+            <var>Accuracy</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      h = html`<var class="h">Hits</var>`;
-      m = html`<var class="m">Misses</var>`;
-      fa = html`<var class="fa">False Alarms</var>`;
-      cr = html`<var class="cr">Correct Rejections</var>`;
-      acc = html`<var class="acc">Accuracy</var>`;
+      h = mathml`<mtext class="math-id h">Hits</mtext>`;
+      m = mathml`<mtext class="math-id m">Misses</mtext>`;
+      fa = mathml`<mtext class="math-id fa">False Alarms</mtext>`;
+      cr = mathml`<mtext class="math-id cr">Correct Rejections</mtext>`;
+      acc = mathml`<mtext class="math-id acc">Accuracy</mtext>`;
     }
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            <tr>
-              <td rowspan="2">
-                ${acc}<span class="equals">=</span>
-              </td>
-              <td class="underline">
-                ${h}<span class="plus">+</span>${cr}
-              </td>
-            </tr>
-            <tr>
-              <td>
-                ${h}<span class="plus">+</span>${cr}<span class="plus">+</span>${m}<span class="plus">+</span>${fa}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${acc}
+            <mo>=</mo>
+            <mfrac>
+              <mrow>
+                ${h}
+                <mo>+</mo>
+                ${cr}
+              </mrow>
+              <mrow>
+                ${h}
+                <mo>+</mo>
+                ${cr}
+                <mo>+</mo>
+                ${m}
+                <mo>+</mo>
+                ${fa}
+              </mrow>
+            </mfrac>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            \\text{Accuracy} = \\frac{\\text{Hits} + \\text{Correct Rejections}}
+              {\\text{Hits} + \\text{Correct Rejections} + \\text{Misses} + \\text{False Alarms}}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            "Accuracy" = ("Hits" + "Correct Rejections") / 
+              ("Hits" + "Correct Rejections" + "Misses" + "False Alarms")
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/detectable-elements/src/equations/hrfar2c.js
+++ b/libraries/detectable-elements/src/equations/hrfar2c.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import SDTMath from '@decidables/detectable-math';
@@ -98,108 +98,215 @@ export default class SDTEquationHrFar2C extends SDTEquation {
     let s;
     let c;
     if (this.numeric) {
-      hr = html`
-        <decidables-spinner class="hr bottom"
-          ?disabled=${!this.interactive}
-          min="0"
-          max="1"
-          step=".001"
-          .value=${this.hr}
-          @input=${this.hrInput.bind(this)}
-        >
-          <var>Hit Rate</var>
-        </decidables-spinner>
-      `;
-      far = html`
-        <decidables-spinner class="far bottom"
-          ?disabled=${!this.interactive}
-          min="0"
-          max="1"
-          step=".001"
-          .value=${this.far}
-          @input=${this.farInput.bind(this)}
-        >
-          <var>False Alarm Rate</var>
-        </decidables-spinner>
-      `;
-      s = html`
-        <decidables-spinner class="s bottom"
-          ?disabled=${!this.interactive}
-          min=${SDTMath.s.MIN}
-          step=${SDTMath.s.STEP}
-          .value=${this.s}
-          @input=${this.sInput.bind(this)}
-        >
-          <var class="math-var">σ</var>
-        </decidables-spinner>
-      `;
-      c = html`
-        <decidables-spinner class="c bottom"
-          disabled
-          step=${SDTMath.c.MIN}
-          .value=${+this.c.toFixed(3)}
-        >
-          <var class="math-var">c</var>
-        </decidables-spinner>
-      `;
+      hr = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math hr"
+            ?disabled=${!this.interactive}
+            min="0"
+            max="1"
+            step=".001"
+            .value=${this.hr}
+            @input=${this.hrInput.bind(this)}
+          >
+            <var>Hit Rate</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      far = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math far"
+            ?disabled=${!this.interactive}
+            min="0"
+            max="1"
+            step=".001"
+            .value=${this.far}
+            @input=${this.farInput.bind(this)}
+          >
+            <var>False Alarm Rate</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      s = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math s"
+            ?disabled=${!this.interactive}
+            min="0"
+            step=".001"
+            .value=${this.s}
+            @input=${this.sInput.bind(this)}
+          >
+            <var class="math-var">σ</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      c = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math c"
+            disabled
+            step=${SDTMath.c.MIN}
+            .value=${+this.c.toFixed(3)}
+          >
+            <var class="math-var">c</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      hr = html`<var class="hr">Hit Rate</var>`;
-      far = html`<var class="far">False Alarm Rate</var>`;
-      s = html`<var class="math-var s">σ</var>`;
-      c = html`<var class="math-var c">c</var>`;
+      hr = mathml`<mtext class="math-id hr">Hit Rate</mtext>`;
+      far = mathml`<mtext class="math-id far">False Alarm Rate</mtext>`;
+      s = mathml`<mi mathvariant="normal" class="math-id s">σ</mi>`;
+      c = mathml`<mi mathvariant="normal" class="math-id c">c</mi>`;
     }
-    let equation;
-    if (this.unequal) {
-      equation = html`
-        <tr>
-          <td rowspan="2">
-            ${c}<span class="equals">=</span><span class="bracket tight">(</span>
-          </td>
-          <td class="underline bottom">
-            <span>1</span><span class="plus tight">+</span><span>${s}<sup class="exp">2</sup></span>
-          </td>
-          <td rowspan="2">
-            <span class="bracket tight">)<sup class="exp">−½</sup></span><span class="bracket tight">(</span>
-          </td>
-          <td class="underline bottom">
-            <span class="minus tight">−</span>${s}
-          </td>
-          <td rowspan="2">
-            <span class="bracket tight">)</span><span class="bracket">[</span><span class="tight"><var class="math-greek phi tight">Φ</var><sup class="exp">−1</sup></span><span class="paren tight">(</span>${hr}<span class="paren tight">)</span><span class="plus">+</span><span class="tight"><var class="math-greek phi tight">Φ</var><sup class="exp">−1</sup></span><span class="paren tight">(</span>${far}<span class="paren tight">)</span><span class="bracket">]</span>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <span>2</span>
-          </td>
-          <td>
-            <span><span>1</span><span class="plus">+</span>${s}</span>
-          </td>
-        </tr>`;
-    } else {
-      equation = html`
-        <tr>
-          <td rowspan="2">
-            ${c}<span class="equals">=</span>
-          </td>
-          <td class="underline">
-            <span class="minus tight">−</span><span class="bracket tight">[</span><span class="tight"><var class="math-greek phi tight">Φ</var><sup class="exp">−1</sup></span><span class="paren tight">(</span>${hr}<span class="paren tight">)</span><span class="plus">+</span><span class="tight"><var class="math-greek phi tight">Φ</var><sup class="exp">−1</sup></span><span class="paren tight">(</span>${far}<span class="paren tight">)</span><span class="bracket tight">]</span>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <span>2</span>
-          </td>
-        </tr>`;
-    }
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${c}
+            <mo>=</mo>
+            ${this.unequal
+              ? mathml`
+                <msup>
+                  <mrow>
+                    <mo symmetric="false">(</mo>
+                    <mfrac>
+                      <mrow>
+                        <mn>1</mn>
+                        <mo>+</mo>
+                        <msup>
+                          <mrow>
+                            ${s}
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </msup>
+                      </mrow>
+                      <mrow>
+                        <mn>2</mn>
+                      </mrow>
+                    </mfrac>
+                    <mo symmetric="false">)</mo>
+                  </mrow>
+                  <mrow>
+                    <mo form="prefix">−</mo>
+                    <mfrac>
+                      <mrow>
+                        <mn>1</mn>
+                      </mrow>
+                      <mrow>
+                        <mn>2</mn>
+                      </mrow>
+                    </mfrac>
+                  </mrow>
+                </msup>
+                <mrow>
+                  <mo symmetric="false">(</mo>
+                  <mfrac>
+                    <mrow>
+                      <mo form="prefix">−</mo>
+                      ${s}
+                    </mrow>
+                    <mrow>
+                      <mn>1</mn>
+                      <mo>+</mo>
+                      ${s}
+                    </mrow>
+                  </mfrac>
+                  <mo symmetric="false">)</mo>
+                </mrow>
+                <mrow>
+                  <mo>[</mo>
+                  <mrow>
+                    <msup>
+                      <mrow>
+                        <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+                      </mrow>
+                      <mrow>
+                        <mn>−1</mn>
+                      </mrow>
+                    </msup>
+                    <mrow>
+                      <mo>(</mo>
+                      ${hr}
+                      <mo>)</mo>
+                    </mrow>
+                    <mo>−</mo>
+                    <msup>
+                      <mrow>
+                        <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+                      </mrow>
+                      <mrow>
+                        <mn>−1</mn>
+                      </mrow>
+                    </msup>
+                    <mrow>
+                      <mo>(</mo>
+                      <mrow>
+                        ${far}
+                      </mrow>
+                      <mo>)</mo>
+                    </mrow>
+                  </mrow>
+                  <mo>]</mo>
+                </mrow>
+              `
+              : mathml`
+                <mfrac>
+                  <mrow>
+                    <mo form="prefix">−</mo>
+                    <mo>[</mo>
+                    <mrow>
+                      <msup>
+                        <mrow>
+                          <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+                        </mrow>
+                        <mrow>
+                          <mn>−1</mn>
+                        </mrow>
+                      </msup>
+                      <mrow>
+                        <mo>(</mo>
+                        <mrow>
+                          ${hr}
+                        </mrow>
+                        <mo>)</mo>
+                      </mrow>
+                      <mo>−</mo>
+                      <msup>
+                        <mrow>
+                          <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+                        </mrow>
+                        <mrow>
+                          <mn>−1</mn>
+                        </mrow>
+                      </msup>
+                      <mrow>
+                        <mo>(</mo>
+                        <mrow>
+                          ${far}
+                        </mrow>
+                        <mo>)</mo>
+                      </mrow>
+                    </mrow>
+                    <mo>]</mo>
+                  </mrow>
+                  <mrow>
+                    <mn>2</mn>
+                  </mrow>
+                </mfrac>
+              `
+            }
+          </mrow>
+          <annotation encoding="application/x-tex">
+            ${this.unequal
+              ? mathml`d' = \\left(\\frac{1 + \\sigma^2}{2}\\right)^{-\\frac{1}{2}}
+                \\left(\\frac{-\\sigma}{1 + \\sigma}\\right)
+                \\left[\\Phi^{-1}(\\text{Hit Rate}) - \\Phi^{-1}(\\text{False Alarm Rate}) \\right]`
+              : mathml`d' = \\frac{-\\left[\\Phi^{-1}(\\text{Hit Rate}) - \\Phi^{-1}(\\text{False Alarm Rate})\\right]}{2}`
+            }
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            ${this.unequal
+              ? mathml`d' = ((1 + sigma^2) / 2)^(-1/2)
+                (sigma / (1 + sigma))
+                [Phi^(-1)("Hit Rate") - Phi^(-1)("False Alarm Rate")]`
+              : mathml`d' = (-[Phi^-1("Hit Rate") - Phi^-1("False Alarm Rate")]) / 2`
+            }
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/detectable-elements/src/equations/hrfar2d.js
+++ b/libraries/detectable-elements/src/equations/hrfar2d.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import SDTMath from '@decidables/detectable-math';
@@ -98,91 +98,185 @@ export default class SDTEquationHrFar2D extends SDTEquation {
     let s;
     let d;
     if (this.numeric) {
-      hr = html`
-        <decidables-spinner class="hr bottom"
-          ?disabled=${!this.interactive}
-          min="0"
-          max="1"
-          step=".001"
-          .value=${this.hr}
-          @input=${this.hrInput.bind(this)}
-        >
-          <var>Hit Rate</var>
-        </decidables-spinner>
-      `;
-      far = html`
-        <decidables-spinner class="far bottom"
-          ?disabled=${!this.interactive}
-          min="0"
-          max="1"
-          step=".001"
-          .value=${this.far}
-          @input=${this.farInput.bind(this)}
-        >
-          <var>False Alarm Rate</var>
-        </decidables-spinner>
-      `;
-      s = html`
-        <decidables-spinner class="s bottom"
-          ?disabled=${!this.interactive}
-          min="0"
-          step=".001"
-          .value=${this.s}
-          @input=${this.sInput.bind(this)}
-        >
-          <var class="math-var">σ</var>
-        </decidables-spinner>
-      `;
-      d = html`
-        <decidables-spinner class="d bottom"
-          disabled
-          step=${SDTMath.d.STEP}
-          .value=${+this.d.toFixed(3)}
-        >
-          <var class="math-var">d′</var>
-        </decidables-spinner>
-      `;
+      hr = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math hr"
+            ?disabled=${!this.interactive}
+            min="0"
+            max="1"
+            step=".001"
+            .value=${this.hr}
+            @input=${this.hrInput.bind(this)}
+          >
+            <var>Hit Rate</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      far = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math far"
+            ?disabled=${!this.interactive}
+            min="0"
+            max="1"
+            step=".001"
+            .value=${this.far}
+            @input=${this.farInput.bind(this)}
+          >
+            <var>False Alarm Rate</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      s = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math s"
+            ?disabled=${!this.interactive}
+            min="0"
+            step=".001"
+            .value=${this.s}
+            @input=${this.sInput.bind(this)}
+          >
+            <var class="math-var">σ</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      d = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math d"
+            disabled
+            step=${SDTMath.d.STEP}
+            .value=${+this.d.toFixed(3)}
+          >
+            <var class="math-var">d′</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      hr = html`<var class="hr">Hit Rate</var>`;
-      far = html`<var class="far">False Alarm Rate</var>`;
-      s = html`<var class="math-var s">σ</var>`;
-      d = html`<var class="math-var d">d′</var>`;
+      hr = mathml`<mtext class="math-id hr">Hit Rate</mtext>`;
+      far = mathml`<mtext class="math-id far">False Alarm Rate</mtext>`;
+      s = mathml`<mi mathvariant="normal" class="math-id s">σ</mi>`;
+      d = mathml`<mi mathvariant="normal" class="math-id d">d′</mi>`;
     }
-    let equation;
-    if (this.unequal) {
-      equation = html`
-        <tr>
-          <td rowspan="2">
-            ${d}<span class="equals">=</span><span class="bracket tight">(</span>
-          </td>
-          <td class="underline bottom">
-            <span>1</span><span class="plus tight">+</span><span>${s}<sup class="exp">2</sup></span>
-          </td>
-          <td rowspan="2">
-            <span class="bracket tight">)<sup class="exp">−½</sup></span><span class="bracket">[</span>${s}<span class="tight"><var class="math-greek phi tight">Φ</var><sup class="exp">−1</sup></span><span class="paren tight">(</span>${hr}<span class="paren tight">)</span><span class="minus">−</span><span class="tight"><var class="math-greek phi tight">Φ</var><sup class="exp">−1</sup></span><span class="paren tight">(</span>${far}<span class="paren tight">)</span><span class="bracket">]</span>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <span>2</span>
-          </td>
-        </tr>`;
-    } else {
-      equation = html`
-        <tr>
-          <td>
-              ${d}<span class="equals">=</span><span class="tight"><var class="math-greek phi tight">Φ</var><sup class="exp">−1</sup></span><span class="paren tight">(</span>${hr}<span class="paren tight">)</span><span class="minus">−</span><span class="tight"><var class="math-greek phi tight">Φ</var><sup class="exp">−1</sup></span><span class="paren tight">(</span>${far}<span class="paren tight">)</span>
-          </td>
-        </tr>`;
-    }
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${d}
+            <mo>=</mo>
+            ${this.unequal
+              ? mathml`
+                <msup>
+                  <mrow>
+                    <mo symmetric="false">(</mo>
+                    <mfrac>
+                      <mrow>
+                        <mn>1</mn>
+                        <mo>+</mo>
+                        <msup>
+                          <mrow>
+                            ${s}
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </msup>
+                      </mrow>
+                      <mrow>
+                        <mn>2</mn>
+                      </mrow>
+                    </mfrac>
+                    <mo symmetric="false">)</mo>
+                  </mrow>
+                  <mrow>
+                    <mo form="prefix">−</mo>
+                    <mfrac>
+                      <mrow>
+                        <mn>1</mn>
+                      </mrow>
+                      <mrow>
+                        <mn>2</mn>
+                      </mrow>
+                    </mfrac>
+                  </mrow>
+                </msup>
+                <mrow>
+                  <mo>[</mo>
+                  <mrow>
+                    ${s}
+                    <msup>
+                      <mrow>
+                        <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+                      </mrow>
+                      <mrow>
+                        <mn>−1</mn>
+                      </mrow>
+                    </msup>
+                    <mrow>
+                      <mo>(</mo>
+                      ${hr}
+                      <mo>)</mo>
+                    </mrow>
+                    <mo>−</mo>
+                    <msup>
+                      <mrow>
+                        <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+                      </mrow>
+                      <mrow>
+                        <mn>−1</mn>
+                      </mrow>
+                    </msup>
+                    <mrow>
+                      <mo>(</mo>
+                      <mrow>
+                        ${far}
+                      </mrow>
+                      <mo>)</mo>
+                    </mrow>
+                  </mrow>
+                  <mo>]</mo>
+                </mrow>
+              `
+              : mathml`
+                <msup>
+                  <mrow>
+                    <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+                  </mrow>
+                  <mrow>
+                    <mn>−1</mn>
+                  </mrow>
+                </msup>
+                <mrow>
+                  <mo>(</mo>
+                  ${hr}
+                  <mo>)</mo>
+                </mrow>
+                <mo>−</mo>
+                <msup>
+                  <mrow>
+                    <mi mathvariant="normal" class="math-greek phi">Φ</mi>
+                  </mrow>
+                  <mrow>
+                    <mn>−1</mn>
+                  </mrow>
+                </msup>
+                <mrow>
+                  <mo>(</mo>
+                  <mrow>
+                    ${far}
+                  </mrow>
+                  <mo>)</mo>
+                </mrow>
+              `
+            }
+          </mrow>
+          <annotation encoding="application/x-tex">
+            ${this.unequal
+              ? mathml`d' = \\left(\\frac{1 + \\sigma^2}{2}\\right)^{-\\frac{1}{2}}
+                \\left[\\sigma \\Phi^{-1}(\\text{Hit Rate}) - \\Phi^{-1}(\\text{False Alarm Rate}) \\right]`
+              : mathml`d' = \\Phi^{-1}(\\text{Hit Rate}) - \\Phi^{-1}(\\text{False Alarm Rate})`
+            }
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            ${this.unequal
+              ? mathml`d' = ((1 + sigma^2) / 2)^(-1/2)
+                [sigma Phi^(-1)("Hit Rate") - Phi^(-1)("False Alarm Rate")]`
+              : mathml`d' = Phi^-1("Hit Rate") - Phi^-1("False Alarm Rate")`
+            }
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/detectable-elements/src/equations/mcr2fomr.js
+++ b/libraries/detectable-elements/src/equations/mcr2fomr.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import SDTMath from '@decidables/detectable-math';
@@ -77,63 +77,69 @@ export default class SDTEquationMCr2Fomr extends SDTEquation {
     let cr;
     let fomr;
     if (this.numeric) {
-      m = html`
-        <decidables-spinner class="m"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.m}
-          @input=${this.mInput.bind(this)}
-        >
-          <var>Misses</var>
-        </decidables-spinner>
-      `;
-      cr = html`
-        <decidables-spinner class="cr"
-          ?disabled=${!this.interactive}
-          min="0"
-          .value=${this.cr}
-          @input=${this.crInput.bind(this)}
-        >
-          <var>Correct Rejections</var>
-        </decidables-spinner>
-      `;
-      fomr = html`
-        <decidables-spinner class="fomr"
-          disabled
-          min="0"
-          max="1"
-          step=".001"
-          .value=${+this.fomr.toFixed(3)}
-        >
-          <var>False Omission Rate</var>
-        </decidables-spinner>
-      `;
+      m = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math m"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.m}
+            @input=${this.mInput.bind(this)}
+          >
+            <var>Misses</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      cr = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math cr"
+            ?disabled=${!this.interactive}
+            min="0"
+            .value=${this.cr}
+            @input=${this.crInput.bind(this)}
+          >
+            <var>Correct Rejections</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      fomr = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math fomr"
+            disabled
+            min="0"
+            max="1"
+            step=".001"
+            .value=${+this.fomr.toFixed(3)}
+          >
+            <var>False Omission Rate</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      m = html`<var class="m">Misses</var>`;
-      cr = html`<var class="cr">Correct Rejections</var>`;
-      fomr = html`<var class="fomr">False Omission Rate</var>`;
+      m = mathml`<mtext class="math-id m">Misses</mtext>`;
+      cr = mathml`<mtext class="math-id cr">Correct Rejections</mtext>`;
+      fomr = mathml`<mtext class="math-id fomr">False Omission Rate</mtext>`;
     }
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            <tr>
-              <td rowspan="2">
-                ${fomr}<span class="equals">=</span>
-              </td>
-              <td class="underline">
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${fomr}
+            <mo>=</mo>
+            <mfrac>
+              <mrow>
                 ${m}
-              </td>
-            </tr>
-            <tr>
-              <td>
-                ${m}<span class="plus">+</span>${cr}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    `;
+              </mrow>
+              <mrow>
+                ${m}
+                <mo>+</mo>
+                ${cr}
+              </mrow>
+            </mfrac>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            \\text{False Omission Rate} = \\frac{\\text{Misses}}
+              {\\text{Misses} + \\text{Correct Rejections}}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            "False Omission Rate" = "Misses" / ("Misses" + "Correct Rejections")
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/detectable-elements/src/equations/sdt-equation.js
+++ b/libraries/detectable-elements/src/equations/sdt-equation.js
@@ -1,107 +1,19 @@
 
 import {css} from 'lit';
 
+import {DecidablesMixinEquation} from '@decidables/decidables-elements';
+
 import DetectableElement from '../detectable-element';
 
 /*
   SDTEquation Base Class - Not intended for instantiation!
   <sdt-equation>
 */
-export default class SDTEquation extends DetectableElement {
-  static get properties() {
-    return {
-      numeric: {
-        attribute: 'numeric',
-        type: Boolean,
-        reflect: true,
-      },
-    };
-  }
-
-  constructor() {
-    super();
-    this.numeric = false;
-  }
-
+export default class SDTEquation extends DecidablesMixinEquation(DetectableElement) {
   static get styles() {
     return [
       super.styles,
       css`
-        :host {
-          display: block;
-
-          margin: 1rem;
-        }
-
-        /* Containing <div> */
-        .holder {
-          display: flex;
-
-          flex-direction: row;
-
-          justify-content: left;
-        }
-
-        /* Overall <table> */
-        .equation {
-          text-align: center;
-          white-space: nowrap;
-
-          border-collapse: collapse;
-
-          border: 0;
-        }
-
-        /* Modifies <td> */
-        .underline {
-          border-bottom: 1px solid var(---color-text);
-        }
-
-        /* Basic <span> and <var> w/modifiers */
-        span,
-        var {
-          padding: 0 0.25rem;
-
-          font-style: normal;
-        }
-
-        var {
-          border-radius: var(---border-radius);
-        }
-
-        .tight {
-          padding: 0;
-        }
-
-        .paren {
-          font-size: 150%;
-        }
-
-        .bracket {
-          font-size: 175%;
-        }
-
-        .exp {
-          font-size: 0.75rem;
-        }
-
-        /* Input wrapping <label> */
-        decidables-spinner {
-          --decidables-spinner-input-width: 4rem;
-
-          display: inline-block;
-
-          padding: 0.125rem 0.375rem 0.375rem;
-
-          vertical-align: middle;
-
-          border-radius: var(---border-radius);
-        }
-
-        .bottom {
-          vertical-align: bottom;
-        }
-
         /* Color scheme */
         .h {
           background: var(---color-h-light);

--- a/libraries/detectable-elements/test/equations/dc2far.test.js
+++ b/libraries/detectable-elements/test/equations/dc2far.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/dc2far';
 describe('sdt-equation-dc2far', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<sdt-equation-dc2far></sdt-equation-dc2far>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/detectable-elements/test/equations/dc2hr.test.js
+++ b/libraries/detectable-elements/test/equations/dc2hr.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/dc2hr';
 describe('sdt-equation-dc2hr', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<sdt-equation-dc2hr></sdt-equation-dc2hr>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/detectable-elements/test/equations/facr2far.test.js
+++ b/libraries/detectable-elements/test/equations/facr2far.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/facr2far';
 describe('sdt-equation-facr2far', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<sdt-equation-facr2far></sdt-equation-facr2far>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/detectable-elements/test/equations/hfa2ppv.test.js
+++ b/libraries/detectable-elements/test/equations/hfa2ppv.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/hfa2ppv';
 describe('sdt-equation-hfa2ppv', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<sdt-equation-hfa2ppv></sdt-equation-hfa2ppv>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/detectable-elements/test/equations/hm2hr.test.js
+++ b/libraries/detectable-elements/test/equations/hm2hr.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/hm2hr';
 describe('sdt-equation-hm2hr', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<sdt-equation-hm2hr></sdt-equation-hm2hr>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/detectable-elements/test/equations/hmfacr2acc.test.js
+++ b/libraries/detectable-elements/test/equations/hmfacr2acc.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/hmfacr2acc';
 describe('sdt-equation-hmfacr2acc', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<sdt-equation-hmfacr2acc></sdt-equation-hmfacr2acc>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/detectable-elements/test/equations/hrfar2c.test.js
+++ b/libraries/detectable-elements/test/equations/hrfar2c.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/hrfar2c';
 describe('sdt-equation-hrfar2c', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<sdt-equation-hrfar2c></sdt-equation-hrfar2c>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/detectable-elements/test/equations/hrfar2d.test.js
+++ b/libraries/detectable-elements/test/equations/hrfar2d.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/hrfar2d';
 describe('sdt-equation-hrfar2d', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<sdt-equation-hrfar2d></sdt-equation-hrfar2d>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/detectable-elements/test/equations/mcr2fomr.test.js
+++ b/libraries/detectable-elements/test/equations/mcr2fomr.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/mcr2fomr';
 describe('sdt-equation-mcr2fomr', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<sdt-equation-mcr2fomr></sdt-equation-mcr2fomr>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/discountable-elements/src/components/htd-calculation.js
+++ b/libraries/discountable-elements/src/components/htd-calculation.js
@@ -1,5 +1,5 @@
 
-import {css, html} from 'lit';
+import {html, mathml} from 'lit';
 import {animate, fadeIn} from '@lit-labs/motion';
 
 import '@decidables/decidables-elements/spinner';
@@ -116,25 +116,6 @@ export default class HTDCalculation extends HTDEquation {
     this.sendEvent();
   }
 
-  static get styles() {
-    return [
-      super.styles,
-      css`
-        /* :host {
-          display: inline-block;
-        } */
-
-        var {
-          border-radius: var(---border-radius);
-        }
-
-        decidables-spinner {
-          border-radius: var(---border-radius);
-        }
-      `,
-    ];
-  }
-
   willUpdate() {
     this.alignState();
   }
@@ -149,120 +130,154 @@ export default class HTDCalculation extends HTDEquation {
     let vl;
     let vDiff;
     if (this.numeric) {
-      as = html`<decidables-spinner class="a as"
-          ?disabled=${!this.interactive}
-          step="1"
-          .value=${this.as}
-          @input=${this.asInput.bind(this)}
-        >
-          <var class="math-var">A<sub class="subscript">ss</sub></var>
-        </decidables-spinner>`;
-      ds = html`<decidables-spinner class="d ds"
-          ?disabled=${!this.interactive}
-          min="0"
-          step="1"
-          .value=${this.ds}
-          @input=${this.dsInput.bind(this)}
-        >
-          <var class="math-var">D<sub class="subscript">ss</sub></var>
-        </decidables-spinner>`;
-      al = html`<decidables-spinner class="a al"
-          ?disabled=${!this.interactive}
-          step="1"
-          .value=${this.al}
-          @input=${this.alInput.bind(this)}
-        >
-          <var class="math-var">A<sub class="subscript">ll</sub></var>
-        </decidables-spinner>`;
-      dl = html`<decidables-spinner class="d dl"
-          ?disabled=${!this.interactive}
-          min="0"
-          step="1"
-          .value=${this.dl}
-          @input=${this.dlInput.bind(this)}
-        >
-          <var class="math-var">D<sub class="subscript">ll</sub></var>
-        </decidables-spinner>`;
+      as = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math a as"
+            ?disabled=${!this.interactive}
+            step="1"
+            .value=${this.as}
+            @input=${this.asInput.bind(this)}
+          >
+            <var class="math-var">A<sub class="math-text">ss</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      ds = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math d ds"
+            ?disabled=${!this.interactive}
+            min="0"
+            step="1"
+            .value=${this.ds}
+            @input=${this.dsInput.bind(this)}
+          >
+            <var class="math-var">D<sub class="math-text">ss</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      al = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math a al"
+            ?disabled=${!this.interactive}
+            step="1"
+            .value=${this.al}
+            @input=${this.alInput.bind(this)}
+          >
+            <var class="math-var">A<sub class="math-text">ll</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      dl = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math d dl"
+            ?disabled=${!this.interactive}
+            min="0"
+            step="1"
+            .value=${this.dl}
+            @input=${this.dlInput.bind(this)}
+          >
+            <var class="math-var">D<sub class="math-text">ll</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
 
-      k = html`<decidables-spinner class="k"
-          ?disabled=${!this.interactive}
-          min=${HTDMath.k.MIN}
-          max=${HTDMath.k.MAX}
-          step=${HTDMath.k.STEP}
-          .value=${+this.k.toFixed(3)}
-          @input=${this.kInput.bind(this)}
-        >
-          <var class="math-var">k</var>
-        </decidables-spinner>`;
+      k = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math k"
+            ?disabled=${!this.interactive}
+            min=${HTDMath.k.MIN}
+            max=${HTDMath.k.MAX}
+            step=${HTDMath.k.STEP}
+            .value=${this.k}
+            @input=${this.kInput.bind(this)}
+          >
+            <var class="math-var">k</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
 
-      vs = html`<decidables-spinner class="v vs"
-          disabled
-          .value=${+this.vs.toFixed(2)}
-        >
-          <var class="math-var">V<sub class="subscript">ss</sub></var>
-        </decidables-spinner>`;
-      vl = html`<decidables-spinner class="v vl"
-          disabled
-          .value=${+this.vl.toFixed(2)}
-        >
-          <var class="math-var">V<sub class="subscript">ll</sub></var>
-        </decidables-spinner>`;
-      vDiff = html`${(this.vDiff > 0)
-        ? html`<span class="comparison" ${animate({in: fadeIn})}>&gt;</span>`
+      vs = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v vs"
+            disabled
+            .value=${+this.vs.toFixed(3)}
+          >
+            <var class="math-var">V<sub class="math-text">ss</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      vl = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v vl"
+            disabled
+            .value=${+this.vl.toFixed(3)}
+          >
+            <var class="math-var">V<sub class="math-text">ll</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      vDiff = (this.vDiff > 0)
+        ? mathml`<mo ${animate({in: fadeIn})}>&gt;</mo>`
         : (this.vDiff < 0)
-          ? html`<span class="comparison" ${animate({in: fadeIn})}>&lt;</span>`
-          : html`<span class="comparison" ${animate({in: fadeIn})}>=</span>`}`;
+          ? mathml`<mo ${animate({in: fadeIn})}>&lt;</mo>`
+          : mathml`<mo ${animate({in: fadeIn})}>=</mo>`;
     } else {
-      as = html`<var class="math-var a as">A<sub class="subscript">ss</sub></var>`;
-      ds = html`<var class="math-var d ds">D<sub class="subscript">ss</sub></var>`;
-      al = html`<var class="math-var a al">A<sub class="subscript">ll</sub></var>`;
-      dl = html`<var class="math-var d dl">D<sub class="subscript">ll</sub></var>`;
+      as = mathml`<msub class="math-id a as"><mi mathvariant="normal">A</mi><mrow><mtext>ss</mtext></mrow></msub>`;
+      ds = mathml`<msub class="math-id d ds"><mi mathvariant="normal">D</mi><mrow><mtext>ss</mtext></mrow></msub>`;
+      al = mathml`<msub class="math-id a al"><mi mathvariant="normal">A</mi><mrow><mtext>ll</mtext></mrow></msub>`;
+      dl = mathml`<msub class="math-id d dl"><mi mathvariant="normal">D</mi><mrow><mtext>ll</mtext></mrow></msub>`;
 
-      k = html`<var class="math-var k">k</var>`;
+      k = mathml`<mi mathvariant="normal" class="math-id k">k</mi>`;
 
-      vs = html`<var class="math-var v vs">V<sub class="subscript">ss</sub></var>`;
-      vl = html`<var class="math-var v vl">V<sub class="subscript">ll</sub></var>`;
-      vDiff = html`<span class="comparison">≟</span>`;
+      vs = mathml`<msub class="math-id v vs"><mi mathvariant="normal">V</mi><mrow><mtext>ss</mtext></mrow></msub>`;
+      vl = mathml`<msub class="math-id v vl"><mi mathvariant="normal">V</mi><mrow><mtext>ll</mtext></mrow></msub>`;
+      vDiff = mathml`<mo>≟</mo>`;
     }
-    const equation = html`
-      <tr>
-        <td class="underline">
-          ${as}
-        </td>
-        <td rowspan="2">
-          ${vDiff}
-        </td>
-        <td class="underline">
-          ${al}
-        </td>
-      </tr>
-      <tr>
-        <td class="">
-          <span class="paren tight">(</span>1<span class="plus">+</span>${k}${ds}<span class="paren tight">)</span>
-        </td>
-        <td class="">
-          <span class="paren tight">(</span>1<span class="plus">+</span>${k}${dl}<span class="paren tight">)</span>
-        </td>
-      </tr>
-      <tr>
-        <td class="right">
-          ${vs}
-        </td>
-        <td>
-          ${vDiff}
-        </td>
-        <td class="left">
-          ${vl}
-        </td>
-      </tr>`;
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mtable class="layout">
+            <mtr>
+              <mtd class="leftside">
+                <mfrac>
+                  <mrow>
+                    ${as}
+                  </mrow>
+                  <mrow>
+                    <mn>1</mn>
+                    <mo>+</mo>
+                    ${k}
+                    ${ds}
+                  </mrow>
+                </mfrac>
+              </mtd>
+              <mtd>
+                ${vDiff}
+              </mtd>
+              <mtd class="rightside">
+                <mfrac>
+                  <mrow>
+                    ${al}
+                  </mrow>
+                  <mrow>
+                    <mn>1</mn>
+                    <mo>+</mo>
+                    ${k}
+                    ${dl}
+                  </mrow>
+                </mfrac>
+              </mtd>
+            </mtr>
+            <mtr>
+              <mtd class="leftside">
+                ${vs}
+              </mtd>
+              <mtd>
+                ${vDiff}
+              </mtd>
+              <mtd class="rightside">
+                ${vl}
+              </mtd>
+            </mtr>
+          </mtable>
+          <annotation encoding="application/x-tex">
+            \\begin{array}{rcl}
+            \\frac{A_{ss}}{1 + kD_{ss}} & ≟ & \\frac{A_{ll}}{1 + kD_{ll}} \\\\
+            V_{ss} & ≟ & V_{ll}
+            \\end{array}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            {: [A_(ss)/(1 + kD_(ss)), ≟, A_(ll)/(1 + kD_(ll))], [V_(ss), ≟, V_(ll)] :}
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/discountable-elements/src/equations/adk2v.js
+++ b/libraries/discountable-elements/src/equations/adk2v.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import HTDMath from '@decidables/discountable-math';
@@ -95,68 +95,81 @@ export default class HTDEquationADK2V extends HTDEquation {
     let k;
     let v;
     if (this.numeric) {
-      a = html`<decidables-spinner class="a bottom"
-          ?disabled=${!this.interactive}
-          step="1"
-          .value=${this.a}
-          @input=${this.aInput.bind(this)}
-        >
-          <var class="math-var">A</var>
-        </decidables-spinner>`;
-      d = html`<decidables-spinner class="d bottom"
-          ?disabled=${!this.interactive}
-          min="0"
-          step="1"
-          .value=${this.d}
-          @input=${this.dInput.bind(this)}
-        >
-          <var class="math-var">D</var>
-        </decidables-spinner>`;
-      k = html`<decidables-spinner class="k bottom"
-          ?disabled=${!this.interactive}
-          min=${HTDMath.k.MIN}
-          max=${HTDMath.k.MAX}
-          step=${HTDMath.k.STEP}
-          .value=${this.k}
-          @input=${this.kInput.bind(this)}
-        >
-          <var class="math-var">k</var>
-        </decidables-spinner>`;
-      v = html`<decidables-spinner class="v bottom"
-          disabled
-          step=".001"
-          .value=${+this.v.toFixed(3)}
-        >
-          <var class="math-var">V</var>
-        </decidables-spinner>`;
+      a = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math a"
+            ?disabled=${!this.interactive}
+            step="1"
+            .value=${this.a}
+            @input=${this.aInput.bind(this)}
+          >
+            <var class="math-var">A</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      d = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math d"
+            ?disabled=${!this.interactive}
+            min="0"
+            step="1"
+            .value=${this.d}
+            @input=${this.dInput.bind(this)}
+          >
+            <var class="math-var">D</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      k = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math k"
+            ?disabled=${!this.interactive}
+            min=${HTDMath.k.MIN}
+            max=${HTDMath.k.MAX}
+            step=${HTDMath.k.STEP}
+            .value=${this.k}
+            @input=${this.kInput.bind(this)}
+          >
+            <var class="math-var">k</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      v = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v"
+            disabled
+            step=".001"
+            .value=${+this.v.toFixed(3)}
+          >
+            <var class="math-var">V</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      a = html`<var class="math-var a">A</var>`;
-      d = html`<var class="math-var d">D</var>`;
-      k = html`<var class="math-var k">k</var>`;
-      v = html`<var class="math-var v">V</var>`;
+      a = mathml`<mi mathvariant="normal" class="math-id a">A</mi>`;
+      d = mathml`<mi mathvariant="normal" class="math-id d">D</mi>`;
+      k = mathml`<mi mathvariant="normal" class="math-id k">k</mi>`;
+      v = mathml`<mi mathvariant="normal" class="math-id v">V</mi>`;
     }
-    const equation = html`
-      <tr>
-        <td rowspan="2">
-          ${v}<span class="equals">=</span>
-        </td>
-        <td class="underline">
-          ${a}
-        </td>
-      </tr>
-      <tr>
-        <td class="">
-          <span class="paren tight">(</span>1<span class="plus">+</span>${k}${d}<span class="paren tight">)</span>
-        </td>
-      </tr>`;
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${v}
+            <mo>=</mo>
+            <mfrac>
+              <mrow>
+                ${a}
+              </mrow>
+              <mrow>
+                <mn>1</mn>
+                <mo>+</mo>
+                ${k}
+                ${d}
+              </mrow>
+            </mfrac>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            V = \\frac{A}{1 + kD}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            V = A / (1 + kD)
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/discountable-elements/src/equations/htd-equation.js
+++ b/libraries/discountable-elements/src/equations/htd-equation.js
@@ -1,175 +1,19 @@
 
 import {css} from 'lit';
 
+import {DecidablesMixinEquation} from '@decidables/decidables-elements';
+
 import DiscountableElement from '../discountable-element';
 
 /*
   HTDEquation Base Class - Not intended for instantiation!
   <cpt-equation>
 */
-export default class HTDEquation extends DiscountableElement {
-  static get properties() {
-    return {
-      numeric: {
-        attribute: 'numeric',
-        type: Boolean,
-        reflect: true,
-      },
-    };
-  }
-
-  constructor() {
-    super();
-    this.numeric = false;
-  }
-
+export default class HTDEquation extends DecidablesMixinEquation(DiscountableElement) {
   static get styles() {
     return [
       super.styles,
       css`
-        :host {
-          display: block;
-
-          margin: 1rem;
-        }
-
-        /* Containing <div> */
-        .holder {
-          display: flex;
-
-          flex-direction: row;
-
-          justify-content: left;
-        }
-
-        /* Overall <table> */
-        .equation {
-          text-align: center;
-          white-space: nowrap;
-
-          border-collapse: collapse;
-
-          border: 0;
-        }
-
-        /* Modifies <td> */
-        .underline {
-          border-bottom: 1px solid var(---color-text);
-        }
-
-        /* Basic <span> and <var> w/modifiers */
-        span,
-        var {
-          padding: 0 0.25rem;
-
-          font-style: normal;
-        }
-
-        var {
-          border-radius: var(---border-radius);
-        }
-
-        .tight {
-          padding: 0;
-        }
-
-        .paren {
-          font-size: 150%;
-        }
-
-        .bracket {
-          font-size: 175%;
-        }
-
-        .brace {
-          font-size: 200%;
-        }
-
-        .addend {
-          position: relative;
-
-          display: inline-block;
-        }
-
-        .comparison {
-          position: relative;
-
-          display: inline-block;
-
-          font-size: 125%;
-          font-weight: 600;
-        }
-
-        .function {
-          display: inline-block;
-
-          border-radius: var(---border-radius);
-        }
-
-        :host([numeric]) .function {
-          padding: 0.25rem;
-        }
-
-        .exp {
-          display: inline-block;
-
-          font-size: 0.75rem;
-        }
-
-        .subscript {
-          display: inline-block;
-
-          font-size: 66.667%;
-        }
-
-        .summation {
-          display: flex;
-
-          flex-direction: column;
-
-          line-height: 0.8;
-        }
-
-        .sigma {
-          display: inline-block;
-
-          font-size: 200%;
-        }
-
-        /* Input wrapping <label> */
-        decidables-spinner {
-          --decidables-spinner-input-width: 4rem;
-
-          display: inline-block;
-
-          padding: 0.125rem 0.375rem 0.375rem;
-
-          line-height: 1.5;
-          vertical-align: middle;
-
-          border-radius: var(---border-radius);
-        }
-
-        .n {
-          --decidables-spinner-input-width: 2rem;
-        }
-
-        .left {
-          text-align: left;
-        }
-
-        .right {
-          text-align: right;
-        }
-
-        .bottom {
-          vertical-align: bottom;
-        }
-
-        .top {
-          vertical-align: top;
-        }
-
         /* Color scheme */
         /* .win {
           background: var(---color-better);

--- a/libraries/discountable-elements/test/components/htd-calculation.test.js
+++ b/libraries/discountable-elements/test/components/htd-calculation.test.js
@@ -11,7 +11,7 @@ import '../../src/components/htd-calculation';
 describe('htd-calculation', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<htd-calculation></htd-calculation>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/discountable-elements/test/equations/adk2v.test.js
+++ b/libraries/discountable-elements/test/equations/adk2v.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/adk2v';
 describe('htd-equation-adk2v', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<htd-equation-adk2v></htd-equation-adk2v>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/prospectable-elements/src/components/cpt-calculation.js
+++ b/libraries/prospectable-elements/src/components/cpt-calculation.js
@@ -1,5 +1,5 @@
 
-import {css, html} from 'lit';
+import {html, mathml} from 'lit';
 import {animate, fadeIn} from '@lit-labs/motion';
 
 import '@decidables/decidables-elements/spinner';
@@ -124,43 +124,6 @@ export default class CPTCalculation extends CPTEquation {
     this.sendEvent();
   }
 
-  // aInput(e) {
-  //   this.a = parseFloat(e.target.value);
-  //   this.alignState();
-  //   this.sendEvent();
-  // }
-
-  // lInput(e) {
-  //   this.l = parseFloat(e.target.value);
-  //   this.alignState();
-  //   this.sendEvent();
-  // }
-
-  // gInput(e) {
-  //   this.g = parseFloat(e.target.value);
-  //   this.alignState();
-  //   this.sendEvent();
-  // }
-
-  static get styles() {
-    return [
-      super.styles,
-      css`
-        /* :host {
-          display: inline-block;
-        } */
-
-        var {
-          border-radius: var(---border-radius);
-        }
-
-        decidables-spinner {
-          border-radius: var(---border-radius);
-        }
-      `,
-    ];
-  }
-
   willUpdate() {
     this.alignState();
   }
@@ -170,184 +133,235 @@ export default class CPTCalculation extends CPTEquation {
     let xl;
     let pw;
     let xs;
-    // let a;
-    // let l;
-    // let g;
+
     let vw;
     let vl;
     let ww;
     let wl;
     let vs;
+
     let ug;
     let us;
     let uDiff;
+
     if (this.numeric) {
-      xw = html`<decidables-spinner class="x xw"
-          ?disabled=${!this.interactive}
-          .value=${this.xw}
-          @input=${this.xwInput.bind(this)}
-        >
-          <var class="math-var">x<sub class="subscript win">win</sub></var>
-        </decidables-spinner>`;
-      xl = html`<decidables-spinner class="x xl"
-          disabled
-          .value=${this.xl}
-        >
-          <var class="math-var">x<sub class="subscript loss">loss</sub></var>
-        </decidables-spinner>`;
-      pw = html`<decidables-spinner class="p pw"
-          ?disabled=${!this.interactive}
-          min="0"
-          max="1"
-          step=".01"
-          .value=${+this.pw.toFixed(2)}
-          @input=${this.pwInput.bind(this)}
-        >
-          <var class="math-var">p<sub class="subscript win">win</sub></var>
-        </decidables-spinner>`;
-      xs = html`<decidables-spinner class="x xs"
-          ?disabled=${!this.interactive}
-          .value=${this.xs}
-          @input=${this.xsInput.bind(this)}
-        >
-          <var class="math-var">x<sub class="subscript sure">sure</sub></var>
-        </decidables-spinner>`;
-      // a = html`<decidables-spinner class="a"
-      //     ?disabled=${!this.interactive}
-      //     min=${CPTMath.a.MIN}
-      //     max=${CPTMath.a.MAX}
-      //     step=${CPTMath.a.STEP}
-      //     .value=${+this.a.toFixed(3)}
-      //     @input=${this.aInput.bind(this)}
-      //   >
-      //     <var class="math-var">α</var>
-      //   </decidables-spinner>`;
-      // l = html`<decidables-spinner class="l"
-      //     ?disabled=${!this.interactive}
-      //     min=${CPTMath.l.MIN}
-      //     max=${CPTMath.l.MAX}
-      //     step=${CPTMath.l.STEP}
-      //     .value=${+this.l.toFixed(3)}
-      //     @input=${this.lInput.bind(this)}
-      //   >
-      //     <var class="math-var">λ</var>
-      //   </decidables-spinner>`;
-      // g = html`<decidables-spinner class="g"
-      //     ?disabled=${!this.interactive}
-      //     min=${CPTMath.g.MIN}
-      //     max=${CPTMath.g.MAX}
-      //     step=${CPTMath.g.STEP}
-      //     .value=${+this.g.toFixed(3)}
-      //     @input=${this.gInput.bind(this)}
-      //   >
-      //     <var class="math-var">γ</var>
-      //   </decidables-spinner>`;
-      vw = html`<decidables-spinner class="v vw"
-          disabled
-          .value=${+this.vw.toFixed(1)}
-        >
-          <var class="math-var">v<sub class="subscript win">win</sub></var>
-        </decidables-spinner>`;
-      vl = html`<decidables-spinner class="v vl"
-          disabled
-          .value=${+this.vl.toFixed(1)}
-        >
-          <var class="math-var">v<sub class="subscript loss">loss</sub></var>
-        </decidables-spinner>`;
-      ww = html`<decidables-spinner class="w ww"
-          disabled
-          .value=${+this.ww.toFixed(2)}
-        >
-          <var class="math-var">w<sub class="subscript win">win</sub></var>
-        </decidables-spinner>`;
-      wl = html`<decidables-spinner class="w wl"
-          disabled
-          .value=${+this.wl.toFixed(2)}
-        >
-          <var class="math-var">w<sub class="subscript loss">loss</sub></var>
-        </decidables-spinner>`;
-      vs = html`<decidables-spinner class="v vs"
-          disabled
-          .value=${+this.vs.toFixed(1)}
-        >
-          <var class="math-var">v<sub class="subscript sure">sure</sub></var>
-        </decidables-spinner>`;
-      ug = html`<decidables-spinner class="u ug"
-          disabled
-          .value=${+this.ug.toFixed(1)}
-        >
-          <var class="math-var">U<sub class="subscript gamble">gamble</sub></var>
-        </decidables-spinner>`;
-      us = html`<decidables-spinner class="u us"
-          disabled
-          .value=${+this.us.toFixed(1)}
-        >
-          <var class="math-var">U<sub class="subscript sure">sure</sub></var>
-        </decidables-spinner>`;
-      uDiff = html`${(this.uDiff > 0)
-        ? html`<span class="comparison" ${animate({in: fadeIn})}>&gt;</span>`
+      xw = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math x xw"
+            ?disabled=${!this.interactive}
+            .value=${this.xw}
+            @input=${this.xwInput.bind(this)}
+          >
+            <var class="math-var">x<sub class="math-text">win</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      xl = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math x xl"
+            disabled
+            .value=${this.xl}
+          >
+            <var class="math-var">x<sub class="math-text">loss</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      pw = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math p pw"
+            ?disabled=${!this.interactive}
+            min="0"
+            max="1"
+            step=".01"
+            .value=${+this.pw.toFixed(2)}
+            @input=${this.pwInput.bind(this)}
+          >
+            <var class="math-var">p<sub class="math-text">win</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      xs = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math x xs"
+            ?disabled=${!this.interactive}
+            .value=${this.xs}
+            @input=${this.xsInput.bind(this)}
+          >
+            <var class="math-var">x<sub class="math-text">sure</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+
+      vw = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v vw"
+            disabled
+            .value=${+this.vw.toFixed(1)}
+          >
+            <var class="math-var">v<sub class="math-text">win</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      vl = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v vl"
+            disabled
+            .value=${+this.vl.toFixed(1)}
+          >
+            <var class="math-var">v<sub class="math-text">loss</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      ww = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math w ww"
+            disabled
+            .value=${+this.ww.toFixed(2)}
+          >
+            <var class="math-var">w<sub class="math-text">win</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      wl = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math w wl"
+            disabled
+            .value=${+this.wl.toFixed(2)}
+          >
+            <var class="math-var">w<sub class="math-text">loss</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      vs = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v vs"
+            disabled
+            .value=${+this.vs.toFixed(1)}
+          >
+            <var class="math-var">v<sub class="math-text">sure</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+
+      ug = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math u ug"
+            disabled
+            .value=${+this.ug.toFixed(1)}
+          >
+            <var class="math-var">U<sub class="math-text">gamble</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      us = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math u us"
+            disabled
+            .value=${+this.us.toFixed(1)}
+          >
+            <var class="math-var">U<sub class="math-text">sure</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      uDiff = (this.uDiff > 0)
+        ? mathml`<mo ${animate({in: fadeIn})}>&gt;</mo>`
         : (this.uDiff < 0)
-          ? html`<span class="comparison" ${animate({in: fadeIn})}>&lt;</span>`
-          : html`<span class="comparison" ${animate({in: fadeIn})}>=</span>`}`;
+          ? mathml`<mo ${animate({in: fadeIn})}>&lt;</mo>`
+          : mathml`<mo ${animate({in: fadeIn})}>=</mo>`;
     } else {
-      xw = html`<var class="math-var x xw">x<sub class="subscript win">win</sub></var>`;
-      xl = html`<var class="math-var x xl">x<sub class="subscript loss">loss</sub></var>`;
-      pw = html`<var class="math-var p pw">p<sub class="subscript win">win</sub></var>`;
-      xs = html`<var class="math-var x xs">x<sub class="subscript sure">sure</sub></var>`;
-      // a = html`<var class="math-var a">α</var>`;
-      // l = html`<var class="math-var l">λ</var>`;
-      // g = html`<var class="math-var g">γ</var>`;
-      vw = html`<var class="math-var v vw">v<sub class="subscript win">win</sub></var>`;
-      vl = html`<var class="math-var v vl">v<sub class="subscript loss">loss</sub></var>`;
-      ww = html`<var class="math-var w ww">w<sub class="subscript win">win</sub></var>`;
-      wl = html`<var class="math-var w wl">w<sub class="subscript loss">loss</sub></var>`;
-      vs = html`<var class="math-var v vs">v<sub class="subscript sure">sure</sub></var>`;
-      ug = html`<var class="math-var u ug">U<sub class="subscript gamble">gamble</sub></var>`;
-      us = html`<var class="math-var u us">U<sub class="subscript sure">sure</sub></var>`;
-      uDiff = html`<span class="comparison">≟</span>`;
+      xw = mathml`<msub class="math-id x xw"><mi mathvariant="normal">x</mi><mrow><mtext>win</mtext></mrow></msub>`;
+      xl = mathml`<msub class="math-id x xl"><mi mathvariant="normal">x</mi><mrow><mtext>loss</mtext></mrow></msub>`;
+      pw = mathml`<msub class="math-id p pw"><mi mathvariant="normal">p</mi><mrow><mtext>win</mtext></mrow></msub>`;
+      xs = mathml`<msub class="math-id x xs"><mi mathvariant="normal">x</mi><mrow><mtext>sure</mtext></mrow></msub>`;
+
+      vw = mathml`<msub class="math-id v vw"><mi mathvariant="normal">v</mi><mrow><mtext>win</mtext></mrow></msub>`;
+      vl = mathml`<msub class="math-id v vl"><mi mathvariant="normal">v</mi><mrow><mtext>loss</mtext></mrow></msub>`;
+      ww = mathml`<msub class="math-id w ww"><mi mathvariant="normal">w</mi><mrow><mtext>win</mtext></mrow></msub>`;
+      wl = mathml`<msub class="math-id w wl"><mi mathvariant="normal">w</mi><mrow><mtext>loss</mtext></mrow></msub>`;
+      vs = mathml`<msub class="math-id v vs"><mi mathvariant="normal">v</mi><mrow><mtext>sure</mtext></mrow></msub>`;
+
+      ug = mathml`<msub class="math-id u ug"><mi mathvariant="normal">u</mi><mrow><mtext>gamble</mtext></mrow></msub>`;
+      us = mathml`<msub class="math-id u us"><mi mathvariant="normal">u</mi><mrow><mtext>sure</mtext></mrow></msub>`;
+      uDiff = mathml`<mo>≟</mo>`;
     }
-    const equation = html`
-      <tr>
-        <td class="right">
-          <span class="function v"><var class="math-var v tight">v</var><span class="paren tight">(</span>${xw}<span class="paren tight">)</span></span>&nbsp;<span class="function w"><var class="math-var w tight">w</var><span class="paren tight">(</span>${pw}<span class="paren tight">)</span></span><span class="plus">+</span><span class="function v"><var class="math-var v tight">v</var><span class="paren tight">(</span>${xl}<span class="paren tight">)</span></span>&nbsp;<span class="bracket tight">[</span><span class="tight">1</span><span class="minus">−</span><span class="function w"><var class="math-var w">w</var><span class="paren tight">(</span>${pw}<span class="paren tight">)</span></span><span class="bracket tight">]</span>
-        </td>
-        <td>
-          ${uDiff}
-        </td>
-        <td class="left">
-          <span class="function v"><var class="math-var v tight">v</var><span class="paren tight">(</span>${xs}<span class="paren tight">)</span></span>
-        </td>
-      </tr>
-      <tr>
-        <td class="right">
-          ${vw}&nbsp;${ww}<span class="plus">+</span>${vl}&nbsp;${wl}
-        </td>
-        <td>
-          ${uDiff}
-        </td>
-        <td class="left">
-          ${vs}
-        </td>
-      </tr>
-      <tr>
-        <td class="right">
-          ${ug}
-        </td>
-        <td>
-          ${uDiff}
-        </td>
-        <td class="left">
-          ${us}
-        </td>
-      </tr>`;
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mtable class="layout">
+            <mtr>
+              <mtd class="leftside">
+                <mrow>
+                  <mrow class="math-id v">
+                    <mi mathvariant="normal">v</mi>
+                    <mo>(</mo>
+                    ${xw}
+                    <mo>)</mo>
+                  </mrow>
+                  <mrow class="math-id w">
+                    <mi mathvariant="normal">w</mi>
+                    <mo>(</mo>
+                    ${pw}
+                    <mo>)</mo>
+                  </mrow>
+                  <mo>+</mo>
+                  <mrow class="math-id v">
+                    <mi mathvariant="normal">v</mi>
+                    <mo>(</mo>
+                    ${xl}
+                    <mo>)</mo>
+                  </mrow>
+                  <mrow>
+                    <mo>[</mo>
+                    <mrow>
+                      <mn>1</mn>
+                      <mo>−</mo>
+                      <mrow class="math-id w">
+                        <mi mathvariant="normal">w</mi>
+                        <mo>(</mo>
+                        ${pw}
+                        <mo>)</mo>
+                      </mrow>
+                    </mrow>
+                    <mo>]</mo>
+                  </mrow>
+                </mrow>
+              </mtd>
+              <mtd>
+                ${uDiff}
+              </mtd>
+              <mtd class="rightside">
+                <mrow class="math-id v">
+                  <mi mathvariant="normal">v</mi>
+                  <mo>(</mo>
+                  ${xs}
+                  <mo>)</mo>
+                </mrow>
+              </mtd>
+            </mtr>
+            <mtr>
+              <mtd class="leftside">
+                <mrow>
+                  ${vw}
+                  ${ww}
+                  <mo>+</mo>
+                  ${vl}
+                  ${wl}
+                </mrow>
+              </mtd>
+              <mtd>
+                ${uDiff}
+              </mtd>
+              <mtd class="rightside">
+                ${vs}
+              </mtd>
+            </mtr>
+            <mtr>
+              <mtd class="leftside">
+                ${ug}
+              </mtd>
+              <mtd>
+                ${uDiff}
+              </mtd>
+              <mtd class="rightside">
+                ${us}
+              </mtd>
+            </mtr>
+          </mtable>
+          <annotation encoding="application/x-tex">
+            \\begin{array}{rcl}
+            v(x_{\\text{win}})w(p_{\\text{win}}) + v(x_{\\text{loss}})[1 - w(p_{\\text{loss}})] & ≟ & v(x_{\\text{sure}}) \\\\
+            v_{\\text{win}}w_{\\text{win}} + v_{\\text{loss}}w_{\\text{loss}} & ≟ & v_{\\text{sure}} \\\\
+            U_{\\text{gamble}} & ≟ & U_{\\text{sure}}
+            \\end{array}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            {:
+            [v(x_("win"))w(p_("win")) + v(x_("loss"))w(p_("loss")), ≟, v(x_("sure"))],
+            [v_("win")w_("win") + v_("loss")w_("loss"), ≟, v_("sure")],
+            [U_("gamble"), ≟, U_("sure")]
+            :}
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/prospectable-elements/src/equations/cpt-equation.js
+++ b/libraries/prospectable-elements/src/equations/cpt-equation.js
@@ -1,175 +1,19 @@
 
 import {css} from 'lit';
 
+import {DecidablesMixinEquation} from '@decidables/decidables-elements';
+
 import ProspectableElement from '../prospectable-element';
 
 /*
   CPTEquation Base Class - Not intended for instantiation!
   <cpt-equation>
 */
-export default class CPTEquation extends ProspectableElement {
-  static get properties() {
-    return {
-      numeric: {
-        attribute: 'numeric',
-        type: Boolean,
-        reflect: true,
-      },
-    };
-  }
-
-  constructor() {
-    super();
-    this.numeric = false;
-  }
-
+export default class CPTEquation extends DecidablesMixinEquation(ProspectableElement) {
   static get styles() {
     return [
       super.styles,
       css`
-        :host {
-          display: block;
-
-          margin: 1rem;
-        }
-
-        /* Containing <div> */
-        .holder {
-          display: flex;
-
-          flex-direction: row;
-
-          justify-content: left;
-        }
-
-        /* Overall <table> */
-        .equation {
-          text-align: center;
-          white-space: nowrap;
-
-          border-collapse: collapse;
-
-          border: 0;
-        }
-
-        /* Modifies <td> */
-        .underline {
-          border-bottom: 1px solid var(---color-text);
-        }
-
-        /* Basic <span> and <var> w/modifiers */
-        span,
-        var {
-          padding: 0 0.25rem;
-
-          font-style: normal;
-        }
-
-        var {
-          border-radius: var(---border-radius);
-        }
-
-        .tight {
-          padding: 0;
-        }
-
-        .paren {
-          font-size: 150%;
-        }
-
-        .bracket {
-          font-size: 175%;
-        }
-
-        .brace {
-          font-size: 200%;
-        }
-
-        .addend {
-          position: relative;
-
-          display: inline-block;
-        }
-
-        .comparison {
-          position: relative;
-
-          display: inline-block;
-
-          font-size: 125%;
-          font-weight: 600;
-        }
-
-        .function {
-          display: inline-block;
-
-          border-radius: var(---border-radius);
-        }
-
-        :host([numeric]) .function {
-          padding: 0.25rem;
-        }
-
-        .exp {
-          display: inline-block;
-
-          font-size: 0.75rem;
-        }
-
-        .subscript {
-          display: inline-block;
-
-          font-size: 66.667%;
-        }
-
-        .summation {
-          display: flex;
-
-          flex-direction: column;
-
-          line-height: 0.8;
-        }
-
-        .sigma {
-          display: inline-block;
-
-          font-size: 200%;
-        }
-
-        /* Input wrapping <label> */
-        decidables-spinner {
-          --decidables-spinner-input-width: 4rem;
-
-          display: inline-block;
-
-          padding: 0.125rem 0.375rem 0.375rem;
-
-          line-height: 1.5;
-          vertical-align: middle;
-
-          border-radius: var(---border-radius);
-        }
-
-        .n {
-          --decidables-spinner-input-width: 2rem;
-        }
-
-        .left {
-          text-align: left;
-        }
-
-        .right {
-          text-align: right;
-        }
-
-        .bottom {
-          vertical-align: bottom;
-        }
-
-        .top {
-          vertical-align: top;
-        }
-
         /* Color scheme */
         /* .win {
           background: var(---color-better);

--- a/libraries/prospectable-elements/src/equations/pg2w.js
+++ b/libraries/prospectable-elements/src/equations/pg2w.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import CPTMath from '@decidables/prospectable-math';
@@ -74,66 +74,128 @@ export default class CPTEquationPG2W extends CPTEquation {
   }
 
   render() {
+    // Hacks for Firefox:
+    // * Wrap <mtext> with HTML in an <mtable><mtr><mtd> to get vertical alignment correct
+    // * <mi> requires `mathvariant="normal"` in addition to `text-transform: none;` in CSS
+    // * Wrap <mn> in <mrow> within <msub> and <msup> to get font-size correct with `font-family`
     let p;
     let g;
     let w;
     if (this.numeric) {
-      p = html`<decidables-spinner class="p bottom"
-          ?disabled=${!this.interactive}
-          min="0"
-          max="1"
-          step="0.01"
-          .value=${this.p}
-          @input=${this.pInput.bind(this)}
-        >
-          <var class="math-var">p</var>
-        </decidables-spinner>`;
-      g = html`<decidables-spinner class="g bottom"
-          ?disabled=${!this.interactive}
-          min=${CPTMath.g.MIN}
-          max=${CPTMath.g.MAX}
-          step=${CPTMath.g.STEP}
-          .value=${this.g}
-          @input=${this.gInput.bind(this)}
-        >
-          <var class="math-var">γ</var>
-        </decidables-spinner>`;
-      w = html`<decidables-spinner class="w bottom"
-          disabled
-          min="0"
-          max="1"
-          step=".01"
-          .value=${+this.w.toFixed(2)}
-        >
-          <var class="math-var">w</var>
-        </decidables-spinner>`;
+      p = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math p"
+            ?disabled=${!this.interactive}
+            min="0"
+            max="1"
+            step="0.01"
+            .value=${this.p}
+            @input=${this.pInput.bind(this)}
+          >
+            <var class="math-var">p</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      g = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math g"
+            ?disabled=${!this.interactive}
+            min=${CPTMath.g.MIN}
+            max=${CPTMath.g.MAX}
+            step=${CPTMath.g.STEP}
+            .value=${this.g}
+            @input=${this.gInput.bind(this)}
+          >
+            <var class="math-var">γ</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      w = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math w"
+            disabled
+            min="0"
+            max="1"
+            step=".01"
+            .value=${+this.w.toFixed(2)}
+          >
+            <var class="math-var">w</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      p = html`<var class="math-var p">p</var>`;
-      g = html`<var class="math-var g">γ</var>`;
-      w = html`<var class="math-var w">w</var>`;
+      p = mathml`<mi mathvariant="normal" class="math-id p">p</mi>`;
+      g = mathml`<mi mathvariant="normal" class="math-id g">γ</mi>`;
+      w = mathml`<mi mathvariant="normal" class="math-id w">w</mi>`;
     }
-    const equation = html`
-      <tr>
-        <td rowspan="2">
-          ${w}<span class="equals">=</span>
-        </td>
-        <td class="underline">
-          ${p}<sup class="exp">${g}</sup>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <span class="bracket tight">[</span>${p}<sup class="exp">${g}</sup><span class="plus">+</span><span class="paren tight">(</span>1<span class="minus">−</span>${p}<span class="paren tight">)</span><sup class="exp">${g}</sup><span class="bracket tight">]</span><sup class="exp">1/${g}</sup>
-        </td>
-      </tr>`;
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${w}
+            <mo>=</mo>
+            <mfrac>
+              <mrow>
+                <msup>
+                  <mrow>
+                    ${p}
+                  </mrow>
+                  <mrow>
+                    ${g}
+                  </mrow>
+                </msup>
+              </mrow>
+              <mrow>
+                <msup>
+                  <mrow>
+                    <mo symmetric="false">[</mo>
+                    <mrow>
+                      <msup>
+                        <mrow>
+                          ${p}
+                        </mrow>
+                        <mrow>
+                          ${g}
+                        </mrow>
+                      </msup>
+                      <mo>+</mo>
+                      <msup>
+                        <mrow>
+                          <mo symmetric="false">(</mo>
+                          <mrow>
+                            <mn>1</mn>
+                            <mo>−</mo>
+                            ${p}
+                          </mrow>
+                          <mo symmetric="false">)</mo>
+                        </mrow>
+                        <mrow>
+                          ${g}
+                        </mrow>
+                      </msup>
+                    </mrow>
+                    <mo symmetric="false">]</mo>
+                  </mrow>
+                  <mrow>
+                    <mfrac>
+                      <mrow>
+                        <mn>1</mn>
+                      </mrow>
+                      <mrow>
+                        ${g}
+                      </mrow>
+                    </mfrac>
+                    <!-- <mn>1</mn>
+                    <mo stretchy="true">⁄</mo>
+                    ${g} -->
+                  </mrow>
+                </msup>
+              </mrow>
+            </mfrac>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            w = \\frac{p^\\gamma}{[p^\\gamma + (1 - p)^\\gamma]^{1 / \\gamma}}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            w = p^gamma / [p^gamma + (1 - p)^gamma] ^ (1 // gamma)
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/prospectable-elements/src/equations/vw2u.js
+++ b/libraries/prospectable-elements/src/equations/vw2u.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 import {animate, flyLeft} from '@lit-labs/motion';
 
 import '@decidables/decidables-elements/spinner';
@@ -107,39 +107,57 @@ export default class CPTEquationVW2U extends CPTEquation {
     this.sendEvent();
   }
 
-  vTemplate(subscript = '', className = '', numeric = false) {
+  vTemplate(subscript = '', symbolic = true, numeric = false) {
     let v;
     if (numeric) {
       const index = Number.parseInt(subscript, 10) - 1;
-      v = html`<decidables-spinner class="v"
-          ?disabled=${!this.interactive}
-          .value=${this.v[index]}
-          @input=${this.vInput.bind(this, index)}
-        >
-          <var class="math-var">v<sub class="subscript ${className}">${subscript}</sub></var>
-        </decidables-spinner>`;
+      v = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v"
+            ?disabled=${!this.interactive}
+            .value=${this.v[index]}
+            @input=${this.vInput.bind(this, index)}
+          >
+            <var class="math-var">v<sub class="${symbolic ? 'math-var' : 'math-num'}">${subscript}</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      v = html`<var class="math-var v">v<sub class="subscript ${className}">${subscript}</sub></var>`;
+      v = mathml`<msub class="math-id v">
+          <mi mathvariant="normal">v</mi>
+          <mrow>
+            ${symbolic
+              ? mathml`<mi mathvariant="normal">${subscript}</mi>`
+              : mathml`<mn>${subscript}</mn>`}
+          </mrow>
+        </msub>`;
     }
     return v;
   }
 
-  wTemplate(subscript = '', className = '', numeric = false) {
+  wTemplate(subscript = '', symbolic = true, numeric = false) {
     let w;
     if (numeric) {
       const index = Number.parseInt(subscript, 10) - 1;
-      w = html`<decidables-spinner class="w"
-          ?disabled=${!this.interactive}
-          min="0"
-          max="1"
-          step=".001"
-          .value=${this.w[index]}
-          @input=${this.wInput.bind(this, index)}
-        >
-          <var class="math-var">w<sub class="subscript ${className}">${subscript}</sub></var>
-        </decidables-spinner>`;
+      w = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math w"
+            ?disabled=${!this.interactive}
+            min="0"
+            max="1"
+            step=".001"
+            .value=${this.w[index]}
+            @input=${this.wInput.bind(this, index)}
+          >
+            <var class="math-var">w<sub class="${symbolic ? 'math-var' : 'math-num'}">${subscript}</sub></var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      w = html`<var class="math-var w">w<sub class="subscript ${className}">${subscript}</sub></var>`;
+      w = mathml`<msub class="math-id w">
+          <mi mathvariant="normal">w</mi>
+          <mrow>
+            ${symbolic
+              ? mathml`<mi mathvariant="normal">${subscript}</mi>`
+              : mathml`<mn>${subscript}</mn>`}
+          </mrow>
+        </msub>`;
     }
     return w;
   }
@@ -152,80 +170,84 @@ export default class CPTEquationVW2U extends CPTEquation {
     let u;
     let n;
     if (this.numeric) {
-      u = html`<decidables-spinner class="u"
-          disabled
-          .value=${+this.u.toFixed(3)}
-        >
-          <var class="math-var">U</var>
-        </decidables-spinner>`;
-      n = html`<decidables-spinner class="n"
-          ?disabled=${!this.interactive}
-          min="1"
-          max="4"
-          step="1"
-          .value=${this.n}
-          @input=${this.nInput.bind(this)}
-        >
-          <var class="math-var">n</var>
-        </decidables-spinner>`;
+      u = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math u"
+            disabled
+            .value=${+this.u.toFixed(3)}
+          >
+            <var class="math-var">U</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      n = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math n sum-over"
+            ?disabled=${!this.interactive}
+            min="1"
+            max="4"
+            step="1"
+            .value=${this.n}
+            @input=${this.nInput.bind(this)}
+          >
+            <var class="math-var">n</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      u = html`<var class="math-var u">U</var>`;
-      n = html`<var class="math-var subscript">n</var>`;
+      u = mathml`<mi mathvariant="normal" class="math-id u">U</mi>`;
+      n = mathml`<mi mathvariant="normal" class="math-id n">n</mi>`;
     }
-    const equation = html`
-      <tr>
-        <td>
-          ${u}<span class="equals">=</span>
-        </td>
-        <td>
-          <div class="summation">
-            <span class="tight">${n}</span>
-            <span class="tight"><var class="math-greek sigma">Σ</var></span>
-            <span class="tight"><var class="math-var subscript tight">i</var><span class="equals subscript">=</span><span class="subscript tight">1</span></span>
-          </div>
-        </td>
-        <td>
-          ${
-            this.vTemplate('i', 'math-var', false)
-          }&nbsp;${
-            this.wTemplate('i', 'math-var', false)
-          }<span class="equals">=</span>
-        </td>
-        <td>
-          ${this.numeric
-            ? Array(this.nMax).fill().map((_, index) => {
-              return (index < this.n)
-                ? html`<span class="addend tight" ${animate({in: flyLeft, out: flyLeft})}>${
-                  (index !== 0)
-                    ? html`<span class="plus">+</span>`
-                    : html``
-                  }${
-                    this.vTemplate(index + 1, 'math-num', true)
-                  }&nbsp;${
-                    this.wTemplate(index + 1, 'math-num', true)
-                  }</span>`
-                : null;
-            })
-            : html`${
-              this.vTemplate('1', 'math-num', false)
-            }&nbsp;${
-              this.wTemplate('1', 'math-num', false)
-            }<span class="plus">+</span><span class="ellipsis">…</span><span class="plus">+</span>${
-              this.vTemplate('n', 'math-var', false)
-            }&nbsp;${
-              this.wTemplate('n', 'math-var', false)
-            }`
-          }
-        </td>
-      </tr>`;
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${u}
+            <mo>=</mo>
+            <munderover>
+              <mo>∑</mo>
+              <mrow>
+                <mi mathvariant="normal">i</mi>
+                <mo>=</mo>
+                <mn>1</mn>
+              </mrow>
+              <mrow>
+                ${n}
+              </mrow>
+            </munderover>
+            ${this.vTemplate('i', true, false)}
+            ${this.wTemplate('i', true, false)}
+            <mo>=</mo>
+            ${this.numeric
+              ? Array(this.nMax).fill().map((_, index) => {
+                return (index < this.n)
+                  ? mathml`
+                    <mrow ${animate({in: flyLeft, out: flyLeft})}>
+                    ${(index !== 0)
+                      ? mathml`<mo>+</mo>`
+                      : mathml``
+                    }
+                    ${this.vTemplate(index + 1, false, true)}
+                    ${this.wTemplate(index + 1, false, true)}
+                  </mrow>`
+                  : null;
+              })
+              : mathml`
+                ${this.vTemplate('1', false, false)}
+                ${this.wTemplate('1', false, false)}
+                <mo>+</mo>
+                <mo>⋯</mo>
+                <mo>+</mo>
+                ${this.vTemplate('n', true, false)}
+                ${this.wTemplate('n', true, false)}
+              `
+            }
+          </mrow>
+          <annotation encoding="application/x-tex">
+            U = \\sum_{i=1}^{n} {v_i w_i} = v_1 w_1 + \\cdots + v_n w_n
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            U = sum_(i=1)^n v_i w_i = v_1 w_1 + cdots + v_n w_n
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/prospectable-elements/src/equations/xal2v.js
+++ b/libraries/prospectable-elements/src/equations/xal2v.js
@@ -1,5 +1,5 @@
 
-import {html} from 'lit';
+import {html, mathml} from 'lit';
 
 import '@decidables/decidables-elements/spinner';
 import CPTMath from '@decidables/prospectable-math';
@@ -92,64 +92,131 @@ export default class CPTEquationXAL2V extends CPTEquation {
     let l;
     let v;
     if (this.numeric) {
-      x = html`<decidables-spinner class="x bottom"
-          ?disabled=${!this.interactive}
-          step="1"
-          .value=${this.x}
-          @input=${this.xInput.bind(this)}
-        >
-          <var class="math-var">x</var>
-        </decidables-spinner>`;
-      a = html`<decidables-spinner class="a bottom"
-          ?disabled=${!this.interactive}
-          min=${CPTMath.a.MIN}
-          max=${CPTMath.a.MAX}
-          step=${CPTMath.a.STEP}
-          .value=${this.a}
-          @input=${this.aInput.bind(this)}
-        >
-          <var class="math-var">α</var>
-        </decidables-spinner>`;
-      l = html`<decidables-spinner class="l bottom"
-          ?disabled=${!this.interactive}
-          min=${CPTMath.l.MIN}
-          step=${CPTMath.l.STEP}
-          .value=${this.l}
-          @input=${this.lInput.bind(this)}
-        >
-          <var class="math-var">λ</var>
-        </decidables-spinner>`;
-      v = html`<decidables-spinner class="v bottom" disabled step=".001" .value="${+this.v.toFixed(3)}">
-          <var class="math-var">v</var>
-        </decidables-spinner>`;
+      x = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math x"
+            ?disabled=${!this.interactive}
+            step="1"
+            .value=${this.x}
+            @input=${this.xInput.bind(this)}
+          >
+            <var class="math-var">x</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      a = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math a"
+            ?disabled=${!this.interactive}
+            min=${CPTMath.a.MIN}
+            max=${CPTMath.a.MAX}
+            step=${CPTMath.a.STEP}
+            .value=${this.a}
+            @input=${this.aInput.bind(this)}
+          >
+            <var class="math-var">α</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      l = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math l"
+            ?disabled=${!this.interactive}
+            min=${CPTMath.l.MIN}
+            step=${CPTMath.l.STEP}
+            .value=${this.l}
+            @input=${this.lInput.bind(this)}
+          >
+            <var class="math-var">λ</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
+      v = mathml`<mtable><mtr><mtd><mtext>
+          <decidables-spinner class="math v"
+            disabled
+            step=".001"
+            .value=${+this.v.toFixed(3)}
+          >
+            <var class="math-var">v</var>
+          </decidables-spinner>
+        </mtext></mtd></mtr></mtable>`;
     } else {
-      x = html`<var class="math-var x">x</var>`;
-      a = html`<var class="math-var a">α</var>`;
-      l = html`<var class="math-var l">λ</var>`;
-      v = html`<var class="math-var v">v</var>`;
+      x = mathml`<mi mathvariant="normal" class="math-id x">x</mi>`;
+      a = mathml`<mi mathvariant="normal" class="math-id a">α</mi>`;
+      l = mathml`<mi mathvariant="normal" class="math-id l">λ</mi>`;
+      v = mathml`<mi mathvariant="normal" class="math-id v">v</mi>`;
     }
-    const equation = html`
-      <tr>
-        <td rowspan="2">
-          ${v}<span class="equals">=</span><span class="brace tight">{</span>
-        </td>
-        <td class="left">
-          ${x}<sup class="exp">${a}</sup>,&emsp;if ${x}<span class="equals">&ge;</span>0
-        </td>
-      </tr>
-      <tr>
-        <td class="left">
-          <span class="minus tight">−</span>${l}<span class="paren tight">(</span><span class="minus tight">−</span>${x}<span class="paren tight">)</span><sup class="exp">${a}</sup>,&emsp;if ${x}<span class="equals">&lt;</span>0
-        </td>
-      </tr>`;
-    return html`
-      <div class="holder">
-        <table class="equation">
-          <tbody>
-            ${equation}
-          </tbody>
-        </table>
-      </div>`;
+    return html`<div class="holder">
+      <math display="block">
+        <semantics>
+          <mrow>
+            ${v}
+            <mo>=</mo>
+            <mrow>
+              <mo symmetric="false">{</mo>
+              <mtable>
+                <mtr>
+                  <mtd style="text-align: left;">
+                    <mrow>
+                      <msup>
+                        <mrow>
+                          ${x}
+                        </mrow>
+                        <mrow>
+                          ${a}
+                        </mrow>
+                      </msup>
+                      <mtext>,</mtext>
+                    </mrow>
+                  </mtd>
+                  <mtd style="text-align: left;">
+                    <mrow>
+                      <mtext>&emsp;if&nbsp;</mtext>
+                      ${x}
+                      <mo>&ge;</mo>
+                      <mn>0</mn>
+                    </mrow>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd style="text-align: left;">
+                    <mrow>
+                      <mo form="prefix">−</mo>
+                      ${l}
+                      <msup>
+                        <mrow>
+                          <mo symmetric="false">(</mo>
+                            <mrow>
+                              <mo form="prefix">−</mo>
+                              ${x}
+                            </mrow>
+                          <mo symmetric="false">)</mo>
+                        </mrow>
+                        <mrow>
+                          ${a}
+                        </mrow>
+                      </msup>
+                      <mtext>,</mtext>
+                    </mrow>
+                  </mtd>
+                  <mtd style="text-align: left;">
+                    <mrow>
+                      <mtext>&emsp;if&nbsp;</mtext>
+                      ${x}
+                      <mo>&lt;</mo>
+                      <mn>0</mn>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mrow>
+          </mrow>
+          <annotation encoding="application/x-tex">
+            v = \\begin{cases}
+                x^\\lpha, & \\text{if } x \\ge 0 \\
+                -\\lambda (-x)^\\alpha, & \\text{if } x < 0
+            \\end{cases}
+          </annotation>
+          <annotation encoding="application/x-asciimath">
+            v = {(x^alpha text(,), if x >= 0),(-lambda(-x)^alpha text(,), if x < 0):}
+          </annotation>
+        </semantics>
+      </math>
+    </div>`;
   }
 }
 

--- a/libraries/prospectable-elements/test/components/cpt-calculation.test.js
+++ b/libraries/prospectable-elements/test/components/cpt-calculation.test.js
@@ -11,7 +11,7 @@ import '../../src/components/cpt-calculation';
 describe('cpt-calculation', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<cpt-calculation></cpt-calculation>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/prospectable-elements/test/equations/pg2w.test.js
+++ b/libraries/prospectable-elements/test/equations/pg2w.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/pg2w';
 describe('cpt-equation-pg2w', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<cpt-equation-pg2w></cpt-equation-pg2w>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/prospectable-elements/test/equations/vw2u.test.js
+++ b/libraries/prospectable-elements/test/equations/vw2u.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/vw2u';
 describe('cpt-equation-vw2u', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<cpt-equation-vw2u></cpt-equation-vw2u>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/libraries/prospectable-elements/test/equations/xal2v.test.js
+++ b/libraries/prospectable-elements/test/equations/xal2v.test.js
@@ -11,7 +11,7 @@ import '../../src/equations/xal2v';
 describe('cpt-equation-xal2v', () => {
   it('has a shadowDom', async () => {
     const el = await fixture(html`<cpt-equation-xal2v></cpt-equation-xal2v>`);
-    expect(el.shadowRoot).to.have.descendant('.equation');
+    expect(el.shadowRoot).to.have.descendant('math');
   });
 
   it('has an empty lightDom', async () => {

--- a/sites/accumulable/package.json
+++ b/sites/accumulable/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@decidables/accumulable-elements": "^0.4.0",
     "@decidables/decidables-site": "^0.7.1",
+    "@fontsource/dejavu-math": "^5.2.5",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
     "core-js": "^3.48.0",

--- a/sites/dable/package.json
+++ b/sites/dable/package.json
@@ -32,6 +32,7 @@
     "@decidables/detectable-elements": "^0.6.0",
     "@decidables/discountable-elements": "^0.7.0",
     "@decidables/prospectable-elements": "^0.6.0",
+    "@fontsource/dejavu-math": "^5.2.5",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
     "core-js": "^3.48.0",

--- a/sites/decidables/package.json
+++ b/sites/decidables/package.json
@@ -32,6 +32,7 @@
     "@decidables/detectable-elements": "^0.6.0",
     "@decidables/discountable-elements": "^0.7.0",
     "@decidables/prospectable-elements": "^0.6.0",
+    "@fontsource/dejavu-math": "^5.2.5",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
     "core-js": "^3.48.0",

--- a/sites/detectable/package.json
+++ b/sites/detectable/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@decidables/decidables-site": "^0.7.1",
     "@decidables/detectable-elements": "^0.6.0",
+    "@fontsource/dejavu-math": "^5.2.5",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
     "core-js": "^3.48.0",

--- a/sites/discountable/package.json
+++ b/sites/discountable/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@decidables/decidables-site": "^0.7.1",
     "@decidables/discountable-elements": "^0.7.0",
+    "@fontsource/dejavu-math": "^5.2.5",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
     "core-js": "^3.48.0",

--- a/sites/prospectable/package.json
+++ b/sites/prospectable/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@decidables/decidables-site": "^0.7.1",
     "@decidables/prospectable-elements": "^0.6.0",
+    "@fontsource/dejavu-math": "^5.2.5",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
     "core-js": "^3.48.0",

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -24,7 +24,7 @@ export default {
   ],
   testFramework: {
     config: {
-      timeout: '5000',
+      timeout: '20000',
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,6 +1456,7 @@ __metadata:
   dependencies:
     "@decidables/accumulable-elements": "npm:^0.4.0"
     "@decidables/decidables-site": "npm:^0.7.1"
+    "@fontsource/dejavu-math": "npm:^5.2.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.48.0"
@@ -1476,6 +1477,7 @@ __metadata:
     "@decidables/detectable-elements": "npm:^0.6.0"
     "@decidables/discountable-elements": "npm:^0.7.0"
     "@decidables/prospectable-elements": "npm:^0.6.0"
+    "@fontsource/dejavu-math": "npm:^5.2.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.48.0"
@@ -1514,6 +1516,7 @@ __metadata:
     "@decidables/detectable-elements": "npm:^0.6.0"
     "@decidables/discountable-elements": "npm:^0.7.0"
     "@decidables/prospectable-elements": "npm:^0.6.0"
+    "@fontsource/dejavu-math": "npm:^5.2.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.48.0"
@@ -1555,6 +1558,7 @@ __metadata:
   dependencies:
     "@decidables/decidables-site": "npm:^0.7.1"
     "@decidables/detectable-elements": "npm:^0.6.0"
+    "@fontsource/dejavu-math": "npm:^5.2.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.48.0"
@@ -1595,6 +1599,7 @@ __metadata:
   dependencies:
     "@decidables/decidables-site": "npm:^0.7.1"
     "@decidables/discountable-elements": "npm:^0.7.0"
+    "@fontsource/dejavu-math": "npm:^5.2.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.48.0"
@@ -1637,6 +1642,7 @@ __metadata:
   dependencies:
     "@decidables/decidables-site": "npm:^0.7.1"
     "@decidables/prospectable-elements": "npm:^0.6.0"
+    "@fontsource/dejavu-math": "npm:^5.2.5"
     bootstrap: "npm:^5.3.8"
     bootstrap-icons: "npm:^1.13.1"
     core-js: "npm:^3.48.0"
@@ -1758,6 +1764,13 @@ __metadata:
   dependencies:
     "@types/chai": "npm:^4.2.12"
   checksum: 10/d8571030a5869a3c2d148390a0f66e9ea0cb3740f423acbe9cdd4c95514e7e9a26d50957c9410088f471c75107980e0ba51dd9e3bde2f4fc269e26a4220fa005
+  languageName: node
+  linkType: hard
+
+"@fontsource/dejavu-math@npm:^5.2.5":
+  version: 5.2.5
+  resolution: "@fontsource/dejavu-math@npm:5.2.5"
+  checksum: 10/b7928dcaccdafd52a29e282792346eca14d2e1b6890c504d739f317d680677a0701ef6fbf7252df9c43dfd9d54949da09be23a31fcfa32705da999d43bcbb7d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* add a math font for use in MathML to `decidables-site`
* add `mixin-equation` for equations to `decidables-elements`
* add `dejavu-math` font to all sites for MathML
* convert all equations elements to MathML

BREAKING CHANGE: font-family-math replaced with
font-family-symbol so that font-family-math
can be used for MathML
BREAKING CHANGE: mixin-equation to use as base for all equations

Fixes #7