### PR TITLE
refactor(elements): cleaned up `decidables-elements` imports

### DIFF
--- a/libraries/accumulable-elements/src/accumulable-element.js
+++ b/libraries/accumulable-elements/src/accumulable-element.js
@@ -5,7 +5,7 @@ import {
 } from 'lit';
 import * as d3 from 'd3';
 
-import {DecidablesElement} from '@decidables/decidables-elements';
+import DecidablesElement from '@decidables/decidables-elements/decidables-element';
 
 import {colors} from './colors.yml';
 

--- a/libraries/accumulable-elements/src/components/ddm-model.js
+++ b/libraries/accumulable-elements/src/components/ddm-model.js
@@ -3,7 +3,7 @@ import {css, html, render} from 'lit';
 import * as d3 from 'd3';
 
 import DDMMath from '@decidables/accumulable-math';
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import AccumulableElement from '../accumulable-element';
 

--- a/libraries/accumulable-elements/src/components/rdk-2afc-task.js
+++ b/libraries/accumulable-elements/src/components/rdk-2afc-task.js
@@ -2,7 +2,7 @@
 import {css, html} from 'lit';
 import * as d3 from 'd3';
 
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import AccumulableElement from '../accumulable-element';
 

--- a/libraries/accumulable-elements/src/equations/ddm-equation.js
+++ b/libraries/accumulable-elements/src/equations/ddm-equation.js
@@ -1,7 +1,7 @@
 
 import {css} from 'lit';
 
-import {DecidablesMixinEquation} from '@decidables/decidables-elements';
+import DecidablesMixinEquation from '@decidables/decidables-elements/mixins/mixin-equation';
 
 import AccumulableElement from '../accumulable-element';
 

--- a/libraries/detectable-elements/src/components/detectable-table.js
+++ b/libraries/detectable-elements/src/components/detectable-table.js
@@ -2,7 +2,7 @@
 import {css, html} from 'lit';
 
 import '@decidables/decidables-elements/components/spinner';
-import {DecidablesConverterSet} from '@decidables/decidables-elements';
+import DecidablesConverterSet from '@decidables/decidables-elements/utilities/converter-set';
 import SDTMath from '@decidables/detectable-math';
 
 import DetectableElement from '../detectable-element';

--- a/libraries/detectable-elements/src/components/rdk-task.js
+++ b/libraries/detectable-elements/src/components/rdk-task.js
@@ -2,7 +2,7 @@
 import {css, html} from 'lit';
 import * as d3 from 'd3';
 
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import DetectableElement from '../detectable-element';
 

--- a/libraries/detectable-elements/src/components/roc-space.js
+++ b/libraries/detectable-elements/src/components/roc-space.js
@@ -4,7 +4,7 @@ import * as d3 from 'd3';
 import {interpolatePath} from 'd3-interpolate-path';
 import color from 'color';
 
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 import SDTMath from '@decidables/detectable-math';
 
 import DetectableElement from '../detectable-element';

--- a/libraries/detectable-elements/src/components/sdt-model.js
+++ b/libraries/detectable-elements/src/components/sdt-model.js
@@ -3,7 +3,7 @@ import {css, html, render} from 'lit';
 import * as d3 from 'd3';
 import jStat from 'jstat';
 
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 import SDTMath from '@decidables/detectable-math';
 
 import DetectableElement from '../detectable-element';

--- a/libraries/detectable-elements/src/detectable-element.js
+++ b/libraries/detectable-elements/src/detectable-element.js
@@ -5,7 +5,7 @@ import {
 } from 'lit';
 import * as d3 from 'd3';
 
-import {DecidablesElement} from '@decidables/decidables-elements';
+import DecidablesElement from '@decidables/decidables-elements/decidables-element';
 
 import {colors} from './colors.yml';
 

--- a/libraries/detectable-elements/src/equations/sdt-equation.js
+++ b/libraries/detectable-elements/src/equations/sdt-equation.js
@@ -1,7 +1,7 @@
 
 import {css} from 'lit';
 
-import {DecidablesMixinEquation} from '@decidables/decidables-elements';
+import DecidablesMixinEquation from '@decidables/decidables-elements/mixins/mixin-equation';
 
 import DetectableElement from '../detectable-element';
 

--- a/libraries/detectable-elements/src/examples/multiple.js
+++ b/libraries/detectable-elements/src/examples/multiple.js
@@ -1,5 +1,5 @@
 
-import {DecidablesConverterArray} from '@decidables/decidables-elements';
+import DecidablesConverterArray from '@decidables/decidables-elements/utilities/converter-array';
 
 import SDTExample from './sdt-example';
 

--- a/libraries/discountable-elements/src/components/htd-curves.js
+++ b/libraries/discountable-elements/src/components/htd-curves.js
@@ -3,7 +3,7 @@ import {css, html, render} from 'lit';
 import * as d3 from 'd3';
 
 import HTDMath from '@decidables/discountable-math';
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import DiscountableElement from '../discountable-element';
 

--- a/libraries/discountable-elements/src/discountable-element.js
+++ b/libraries/discountable-elements/src/discountable-element.js
@@ -5,7 +5,7 @@ import {
 } from 'lit';
 import * as d3 from 'd3';
 
-import {DecidablesElement} from '@decidables/decidables-elements';
+import DecidablesElement from '@decidables/decidables-elements/decidables-element';
 
 import {colors} from './colors.yml';
 

--- a/libraries/discountable-elements/src/equations/htd-equation.js
+++ b/libraries/discountable-elements/src/equations/htd-equation.js
@@ -1,7 +1,7 @@
 
 import {css} from 'lit';
 
-import {DecidablesMixinEquation} from '@decidables/decidables-elements';
+import DecidablesMixinEquation from '@decidables/decidables-elements/mixins/mixin-equation';
 
 import DiscountableElement from '../discountable-element';
 

--- a/libraries/prospectable-elements/src/components/cpt-probability.js
+++ b/libraries/prospectable-elements/src/components/cpt-probability.js
@@ -3,7 +3,7 @@ import {css, html, render} from 'lit';
 import * as d3 from 'd3';
 
 import CPTMath from '@decidables/prospectable-math';
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import ProspectableElement from '../prospectable-element';
 

--- a/libraries/prospectable-elements/src/components/cpt-space.js
+++ b/libraries/prospectable-elements/src/components/cpt-space.js
@@ -5,7 +5,7 @@ import * as d33d from 'd3-3d';
 import color from 'color';
 
 import CPTMath from '@decidables/prospectable-math';
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import ProspectableElement from '../prospectable-element';
 

--- a/libraries/prospectable-elements/src/components/cpt-value.js
+++ b/libraries/prospectable-elements/src/components/cpt-value.js
@@ -3,7 +3,7 @@ import {css, html, render} from 'lit';
 import * as d3 from 'd3';
 
 import CPTMath from '@decidables/prospectable-math';
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import ProspectableElement from '../prospectable-element';
 

--- a/libraries/prospectable-elements/src/components/decision-space.js
+++ b/libraries/prospectable-elements/src/components/decision-space.js
@@ -5,7 +5,7 @@ import * as d33d from 'd3-3d';
 import color from 'color';
 
 import CPTMath from '@decidables/prospectable-math';
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import ProspectableElement from '../prospectable-element';
 

--- a/libraries/prospectable-elements/src/components/risky-option.js
+++ b/libraries/prospectable-elements/src/components/risky-option.js
@@ -2,7 +2,7 @@
 import {css, html, render} from 'lit';
 import * as d3 from 'd3';
 
-import {DecidablesMixinResizeable} from '@decidables/decidables-elements';
+import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import ProspectableElement from '../prospectable-element';
 

--- a/libraries/prospectable-elements/src/equations/cpt-equation.js
+++ b/libraries/prospectable-elements/src/equations/cpt-equation.js
@@ -1,7 +1,7 @@
 
 import {css} from 'lit';
 
-import {DecidablesMixinEquation} from '@decidables/decidables-elements';
+import DecidablesMixinEquation from '@decidables/decidables-elements/mixins/mixin-equation';
 
 import ProspectableElement from '../prospectable-element';
 

--- a/libraries/prospectable-elements/src/equations/vw2u.js
+++ b/libraries/prospectable-elements/src/equations/vw2u.js
@@ -3,7 +3,7 @@ import {html, mathml} from 'lit';
 import {animate, flyLeft} from '@lit-labs/motion';
 
 import '@decidables/decidables-elements/components/spinner';
-import {DecidablesConverterArray} from '@decidables/decidables-elements';
+import DecidablesConverterArray from '@decidables/decidables-elements/utilities/converter-array';
 
 import CPTEquation from './cpt-equation';
 

--- a/libraries/prospectable-elements/src/prospectable-element.js
+++ b/libraries/prospectable-elements/src/prospectable-element.js
@@ -5,7 +5,7 @@ import {
 } from 'lit';
 import * as d3 from 'd3';
 
-import {DecidablesElement} from '@decidables/decidables-elements';
+import DecidablesElement from '@decidables/decidables-elements/decidables-element';
 
 import {colors} from './colors.yml';
 


### PR DESCRIPTION
Changed all imports of `decidables-elements` to use full paths instead of destructuring