### PR TITLE
build(root): add `elements` and `math` as commit scopes

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -8,23 +8,25 @@
       "root",
       "all",
       "libraries",
-      "decidables-elements",
       "decidables-site",
-      "accumulable-math",
-      "accumulable-elements",
+      "math",
       "detectable-math",
-      "detectable-elements",
       "prospectable-math",
-      "prospectable-elements",
       "discountable-math",
+      "accumulable-math",
+      "elements",
+      "decidables-elements",
+      "detectable-elements",
+      "prospectable-elements",
       "discountable-elements",
+      "accumulable-elements",
       "sites",
       "decidables",
       "dable",
-      "accumulable",
       "detectable",
       "prospectable",
-      "discountable"
+      "discountable",
+      "accumulable"
     ]]
   }
 }


### PR DESCRIPTION
Changes that impact multiple `*-elements` libraries or `*-math` libraries can now be scoped to `elements` or `math` for precision and clarity.