### PR TITLE
feat(decidables-elements): created mixin for examples

### DIFF
--- a/libraries/accumulable-elements/src/examples/ddm-example.js
+++ b/libraries/accumulable-elements/src/examples/ddm-example.js
@@ -1,71 +1,27 @@
+import {css} from 'lit';
 
-import {css, html} from 'lit';
+import DecidablesMixinExample from '@decidables/decidables-elements/mixins/mixin-example';
 
 import AccumulableElement from '../accumulable-element';
 
 /*
   DDMExample Base Class - Not intended for instantiation!
+  <ddm-example>
 */
-export default class DDMExample extends AccumulableElement {
+export default class DDMExample extends DecidablesMixinExample(AccumulableElement) {
   static get styles() {
     return [
       super.styles,
       css`
-        :host {
-          ---border: var(--border, 1px solid var(---color-border));
-          display: inline-block;
-
-          margin-bottom: 1rem;
-        }
-
-        .holder {
-          display: flex;
-        }
-
-        .body {
-          display: flex;
-
-          flex-wrap: wrap;
-
-          align-items: center;
-          justify-content: left;
-
-          padding: 0.625rem;
-
-          border: var(---border);
-          border-radius: 0.25rem;
-        }
-
-        .body ::slotted(*) {
-          margin: 0.625rem;
-        }
-
         /* HACK: Sibling selectors not working with ::slotted */
-        /* .body > rdk-task + sdt-response,
-        ::slotted(rdk-task) + ::slotted(sdt-response) { */
-        /* .body ::slotted(sdt-response) {
+        /* .body ::slotted(accumulable-control) + ::slotted(rdk-2afc-task),
+           .body ::slotted(rdk-2afc-task) + ::slotted(accumulable-response) { */
+        .body ::slotted(rdk-2afc-task),
+        .body ::slotted(accumulable-response) {
           margin-left: 0;
-        } */
-
-        /* HACK: Sibling selectors not working with ::slotted */
-        /* .body > sdt-control + rdk-task,
-        ::slotted(sdt-control) + ::slotted(rdk-task) {
-          margin-left: 0;
-        } */
-        /* .body ::slotted(rdk-task) {
-          margin-left: 0;
-        } */
+        }
       `,
     ];
-  }
-
-  render() { /* eslint-disable-line class-methods-use-this */
-    return html`
-      <div class="holder">
-        <div class="body">
-          <slot>Empty!</slot>
-        </div>
-      </div>`;
   }
 }
 

--- a/libraries/decidables-elements/src/mixins/index.js
+++ b/libraries/decidables-elements/src/mixins/index.js
@@ -1,3 +1,4 @@
 // Mixins
 export {default as DecidablesMixinEquation} from './mixin-equation';
+export {default as DecidablesMixinExample} from './mixin-example';
 export {default as DecidablesMixinResizeable} from './mixin-resizeable';

--- a/libraries/decidables-elements/src/mixins/mixin-example.js
+++ b/libraries/decidables-elements/src/mixins/mixin-example.js
@@ -1,0 +1,49 @@
+import {css, html} from 'lit';
+
+export default function DecidablesMixinExample(superClass) {
+  return class extends superClass {
+    static get styles() {
+      return [
+        super.styles,
+        css`
+          :host {
+            display: inline-block;
+
+            margin-bottom: 1rem;
+          }
+
+          .holder {
+            display: flex;
+          }
+
+          .body {
+            display: flex;
+
+            flex-wrap: wrap;
+
+            align-items: center;
+            justify-content: left;
+
+            padding: 0.625rem;
+
+            border: var(---border);
+            border-radius: var(---border-radius);
+          }
+
+          .body ::slotted(*) {
+            margin: 0.625rem;
+          }
+        `,
+      ];
+    }
+
+    render() { /* eslint-disable-line class-methods-use-this */
+      return html`
+        <div class="holder">
+          <div class="body">
+            <slot>Empty!</slot>
+          </div>
+        </div>`;
+    }
+  };
+}

--- a/libraries/detectable-elements/src/examples/sdt-example.js
+++ b/libraries/detectable-elements/src/examples/sdt-example.js
@@ -1,5 +1,6 @@
+import {css} from 'lit';
 
-import {css, html} from 'lit';
+import DecidablesMixinExample from '@decidables/decidables-elements/mixins/mixin-example';
 
 import DetectableElement from '../detectable-element';
 
@@ -7,65 +8,20 @@ import DetectableElement from '../detectable-element';
   SDTExample Base Class - Not intended for instantiation!
   <sdt-example>
 */
-export default class SDTExample extends DetectableElement {
+export default class SDTExample extends DecidablesMixinExample(DetectableElement) {
   static get styles() {
     return [
       super.styles,
       css`
-        :host {
-          display: inline-block;
-
-          margin-bottom: 1rem;
-        }
-
-        .holder {
-          display: flex;
-        }
-
-        .body {
-          display: flex;
-
-          flex-wrap: wrap;
-
-          align-items: center;
-          justify-content: left;
-
-          padding: 0.625rem;
-
-          border: var(---border);
-          border-radius: var(---border-radius);
-        }
-
-        .body ::slotted(*) {
-          margin: 0.625rem;
-        }
-
         /* HACK: Sibling selectors not working with ::slotted */
-        /* .body > rdk-task + detectable-response,
-        ::slotted(rdk-task) + ::slotted(detectable-response) { */
+        /* .body ::slotted(detectable-control) + ::slotted(rdk-task),
+           .body ::slotted(rdk-task) + ::slotted(detectable-response) { */
+        .body ::slotted(rdk-task),
         .body ::slotted(detectable-response) {
-          margin-left: 0;
-        }
-
-        /* HACK: Sibling selectors not working with ::slotted */
-        /* .body > detectable-control + rdk-task,
-        ::slotted(detectable-control) + ::slotted(rdk-task) {
-          margin-left: 0;
-        } */
-        .body ::slotted(rdk-task) {
           margin-left: 0;
         }
       `,
     ];
-  }
-
-  render() { /* eslint-disable-line class-methods-use-this */
-    return html`
-      <div class="holder">
-        <div class="body">
-          <slot>Empty!</slot>
-        </div>
-      </div>`;
   }
 }
 

--- a/libraries/discountable-elements/src/examples/htd-example.js
+++ b/libraries/discountable-elements/src/examples/htd-example.js
@@ -1,72 +1,27 @@
+import {css} from 'lit';
 
-import {css, html} from 'lit';
+import DecidablesMixinExample from '@decidables/decidables-elements/mixins/mixin-example';
 
 import DiscountableElement from '../discountable-element';
 
 /*
   CPTExample Base Class - Not intended for instantiation!
-  <sdt-example>
+  <htd-example>
 */
-export default class HTDExample extends DiscountableElement {
+export default class HTDExample extends DecidablesMixinExample(DiscountableElement) {
   static get styles() {
     return [
       super.styles,
       css`
-        :host {
-          ---border: var(--border, 1px solid var(---color-border));
-          display: inline-block;
-
-          margin-bottom: 1rem;
-        }
-
-        .holder {
-          display: flex;
-        }
-
-        .body {
-          display: flex;
-
-          flex-wrap: wrap;
-
-          align-items: center;
-          justify-content: left;
-
-          padding: 0.625rem;
-
-          border: var(---border);
-          border-radius: 0.25rem;
-        }
-
-        .body ::slotted(*) {
-          margin: 0.625rem;
-        }
-
         /* HACK: Sibling selectors not working with ::slotted */
-        /* .body > rdk-task + sdt-response,
-        ::slotted(rdk-task) + ::slotted(sdt-response) { */
-        /* .body ::slotted(sdt-response) {
+        /* .body ::slotted(discountable-control) + ::slotted(itc-task),
+           .body ::slotted(itc-task) + ::slotted(discountable-response) { */
+        .body ::slotted(itc-task),
+        .body ::slotted(discountable-response) {
           margin-left: 0;
-        } */
-
-        /* HACK: Sibling selectors not working with ::slotted */
-        /* .body > sdt-control + rdk-task,
-        ::slotted(sdt-control) + ::slotted(rdk-task) {
-          margin-left: 0;
-        } */
-        /* .body ::slotted(rdk-task) {
-          margin-left: 0;
-        } */
+        }
       `,
     ];
-  }
-
-  render() { /* eslint-disable-line class-methods-use-this */
-    return html`
-      <div class="holder">
-        <div class="body">
-          <slot>Empty!</slot>
-        </div>
-      </div>`;
   }
 }
 

--- a/libraries/prospectable-elements/src/examples/cpt-example.js
+++ b/libraries/prospectable-elements/src/examples/cpt-example.js
@@ -1,72 +1,27 @@
+import {css} from 'lit';
 
-import {css, html} from 'lit';
+import DecidablesMixinExample from '@decidables/decidables-elements/mixins/mixin-example';
 
 import ProspectableElement from '../prospectable-element';
 
 /*
   CPTExample Base Class - Not intended for instantiation!
-  <sdt-example>
+  <cpt-example>
 */
-export default class CPTExample extends ProspectableElement {
+export default class CPTExample extends DecidablesMixinExample(ProspectableElement) {
   static get styles() {
     return [
       super.styles,
       css`
-        :host {
-          ---border: var(--border, 1px solid var(---color-border));
-          display: inline-block;
-
-          margin-bottom: 1rem;
-        }
-
-        .holder {
-          display: flex;
-        }
-
-        .body {
-          display: flex;
-
-          flex-wrap: wrap;
-
-          align-items: center;
-          justify-content: left;
-
-          padding: 0.625rem;
-
-          border: var(---border);
-          border-radius: 0.25rem;
-        }
-
-        .body ::slotted(*) {
-          margin: 0.625rem;
-        }
-
         /* HACK: Sibling selectors not working with ::slotted */
-        /* .body > rdk-task + sdt-response,
-        ::slotted(rdk-task) + ::slotted(sdt-response) { */
-        /* .body ::slotted(sdt-response) {
+        /* .body ::slotted(prospectable-control) + ::slotted(risky-task),
+           .body ::slotted(risky-task) + ::slotted(prospectable-response) { */
+        .body ::slotted(risky-task),
+        .body ::slotted(prospectable-response) {
           margin-left: 0;
-        } */
-
-        /* HACK: Sibling selectors not working with ::slotted */
-        /* .body > sdt-control + rdk-task,
-        ::slotted(sdt-control) + ::slotted(rdk-task) {
-          margin-left: 0;
-        } */
-        /* .body ::slotted(rdk-task) {
-          margin-left: 0;
-        } */
+        }
       `,
     ];
-  }
-
-  render() { /* eslint-disable-line class-methods-use-this */
-    return html`
-      <div class="holder">
-        <div class="body">
-          <slot>Empty!</slot>
-        </div>
-      </div>`;
   }
 }
 


### PR DESCRIPTION
* Created new `mixin-example` with common functionality for examples
* Removed common code from `*-example` now in `mixin-example`
* Added reduced spacing around `*-task` elements

BREAKING CHANGE: new `mixin-example` API for `decidables-elements`

Fixes #8