### PR TITLE
fix(prospectable-elements): fix failing tests in `risky-choice` and `cpt-example-interactive`

### DIFF
--- a/libraries/prospectable-elements/src/components/risky-option.js
+++ b/libraries/prospectable-elements/src/components/risky-option.js
@@ -2,6 +2,7 @@
 import {css, html, render} from 'lit';
 import * as d3 from 'd3';
 
+import '@decidables/decidables-elements/components/spinner';
 import DecidablesMixinResizeable from '@decidables/decidables-elements/mixins/mixin-resizeable';
 
 import ProspectableElement from '../prospectable-element';

--- a/libraries/prospectable-elements/test/examples/interactive.test.js
+++ b/libraries/prospectable-elements/test/examples/interactive.test.js
@@ -5,6 +5,7 @@ import {
   mouseClickElement,
   oneEvent,
   sendKeys,
+  setViewport,
   waitUntil,
 } from '../../../../scripts/test-utility';
 
@@ -186,6 +187,7 @@ describe('cpt-example-interactive', () => {
   });
 
   it('can propagate a cpt-parameters interaction', async () => {
+    await setViewport({width: 1280, height: 1600});
     const el = await fixture(html`
       <cpt-example-interactive alpha="0.75">
         <risky-choice interactive></risky-choice>


### PR DESCRIPTION
* Added import of `decidables-spinner to `risky-option`
* Increased viewport for tests of `cpt-example-interactive`

Fixes #97