### PR TITLE
fix(sites): add `title` and `aria-label` to non-text menu links

### DIFF
--- a/libraries/decidables-site/src/site.ejs
+++ b/libraries/decidables-site/src/site.ejs
@@ -72,22 +72,22 @@
                   <div class="dec-toc-section-name"></div>
                   <ol class="dec-toc-section dec-toc-section-external">
                     <li class="dec-toc-item">
-                      <a class="dec-toc-link" href="https://github.com/decidables/decidables/releases/tag/%40decidables%2F<%- site.package %>%40<%- utilities.getPackageVersion() %>" target="_blank" rel="noopener">
+                      <a class="dec-toc-link" title="Version <%- utilities.getPackageVersion() %>" aria-label="Version <%- utilities.getPackageVersion() %>" href="https://github.com/decidables/decidables/releases/tag/%40decidables%2F<%- site.package %>%40<%- utilities.getPackageVersion() %>" target="_blank" rel="noopener">
                         v<%- utilities.getPackageVersion() %>
                       </a>
                     </li>
                     <li class="dec-toc-item">
-                      <a class="dec-toc-link" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">
+                      <a class="dec-toc-link" title="Creative Commons License CC-BY-SA-4.0" aria-label="Creative Commons License CC-BY-SA-4.0" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">
                         CC-BY-SA-4.0
                       </a>
                     </li>
                     <li class="dec-toc-item">
-                      <a class="dec-toc-link" href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener">
+                      <a class="dec-toc-link" title="GNU General Public License 3.0" aria-label="GNU General Public License 3.0" href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener">
                         GPL-3.0-or-later
                       </a>
                     </li>
                     <li class="dec-toc-item">
-                      <a class="dec-toc-link" href="https://github.com/decidables/decidables/tree/main/sites/<%- site.package %>" target="_blank" rel="noopener">
+                      <a class="dec-toc-link" title="Repository on GitHub" aria-label="Repository on GitHub" href="https://github.com/decidables/decidables/tree/main/sites/<%- site.package %>" target="_blank" rel="noopener">
                         <%- include(require.resolve('bootstrap-icons/icons/github.svg')) %>
                       </a>
                     </li>

--- a/sites/decidables/src/page.ejs
+++ b/sites/decidables/src/page.ejs
@@ -68,20 +68,20 @@ toc:
             </a>
           </li>
           <li class="dec-nav-item">
-            <a class="dec-nav-link" href="https://github.com/decidables/decidables/releases/tag/%40decidables%2Fdecidables%40<%- utilities.getPackageVersion() %>" target="_blank" rel="noopener">
+            <a class="dec-nav-link" title="Version <%- utilities.getPackageVersion() %>" aria-label="Version <%- utilities.getPackageVersion() %>" href="https://github.com/decidables/decidables/releases/tag/%40decidables%2Fdecidables%40<%- utilities.getPackageVersion() %>" target="_blank" rel="noopener">
               v<%- utilities.getPackageVersion() %>
             </a>
           </li>
         </ul>
         <ul class="dec-nav-list">
           <li class="dec-nav-item">
-            <a class="dec-nav-link" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">CC-BY-SA-4.0</a>
+            <a class="dec-nav-link" title="Creative Commons License CC-BY-SA-4.0" aria-label="Creative Commons License CC-BY-SA-4.0" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">CC-BY-SA-4.0</a>
           </li>
           <li class="dec-nav-item">
-            <a class="dec-nav-link" href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener">GPL-3.0-or-later</a>
+            <a class="dec-nav-link" title="GNU General Public License 3.0" aria-label="GNU General Public License 3.0" href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener">GPL-3.0-or-later</a>
           </li>
           <li class="dec-nav-item">
-            <a class="dec-nav-link" href="https://github.com/decidables/decidables/" target="_blank" rel="noopener">
+            <a class="dec-nav-link" title="Repository on GitHub" aria-label="Repository on GitHub" href="https://github.com/decidables/decidables/" target="_blank" rel="noopener">
               <%- include(require.resolve('bootstrap-icons/icons/github.svg')) %>
             </a>
           </li>


### PR DESCRIPTION
Menu links upgraded:
* Version
* Licenses
* Github

Fixes #27