### PR TITLE
test(accumulable-elements): fix timing in `ddm-model` test

### DIFF
--- a/libraries/accumulable-elements/test/components/ddm-model.test.js
+++ b/libraries/accumulable-elements/test/components/ddm-model.test.js
@@ -193,6 +193,7 @@ describe('ddm-model', () => {
       () => { return el.shadowRoot.querySelector('svg'); },
       'Element did not render children',
     );
+    await nextFrame();
     // Get "before" state
     const {z} = el;
     // Action


### PR DESCRIPTION
Added `next-frame()` to fix timing. Not clear when and why this is needed.